### PR TITLE
t/139: Implemented automated registration of child View instances referred in View#template

### DIFF
--- a/src/dropdown/dropdownview.js
+++ b/src/dropdown/dropdownview.js
@@ -28,7 +28,7 @@ export default class DropdownView extends View {
 		 * @readonly
 		 * @member {ui.button.ButtonView} #buttonView
 		 */
-		this.addChildren( this.buttonView = buttonView );
+		this.buttonView = buttonView;
 
 		/**
 		 * Panel of this dropdown view.
@@ -36,7 +36,7 @@ export default class DropdownView extends View {
 		 * @readonly
 		 * @member {module:ui/dropdown/dropdownpanelview~DropdownPanelView} #panelView
 		 */
-		this.addChildren( this.panelView = panelView );
+		this.panelView = panelView;
 
 		/**
 		 * Controls whether the dropdown view is open, which also means its

--- a/tests/view.js
+++ b/tests/view.js
@@ -61,7 +61,7 @@ describe( 'View', () => {
 		} );
 	} );
 
-	describe( 'createCollection', () => {
+	describe( 'createCollection()', () => {
 		beforeEach( () => {
 			setTestViewClass();
 			setTestViewInstance();
@@ -81,7 +81,7 @@ describe( 'View', () => {
 		} );
 	} );
 
-	describe( 'addChildren', () => {
+	describe( 'addChildren()', () => {
 		beforeEach( () => {
 			setTestViewClass();
 			setTestViewInstance();
@@ -192,6 +192,44 @@ describe( 'View', () => {
 		it( 'is null when there is no template', () => {
 			expect( new View().element ).to.be.null;
 		} );
+
+		it( 'registers child views found in the template', () => {
+			const view = new View();
+			const viewA = new View();
+			const viewB = new View();
+			const viewC = new View();
+
+			viewA.template = new Template( { tag: 'a' } );
+			viewB.template = new Template( { tag: 'b' } );
+			viewC.template = new Template( { tag: 'c' } );
+
+			view.template = new Template( {
+				tag: 'div',
+				children: [
+					viewA,
+					viewB,
+					{
+						tag: 'p',
+						children: [
+							viewC
+						]
+					},
+					{
+						text: 'foo'
+					}
+				]
+			} );
+
+			expect( view._unboundChildren ).to.have.length( 0 );
+
+			// Render the view.
+			view.element;
+
+			expect( view._unboundChildren ).to.have.length( 3 );
+			expect( view._unboundChildren.get( 0 ) ).to.equal( viewA );
+			expect( view._unboundChildren.get( 1 ) ).to.equal( viewB );
+			expect( view._unboundChildren.get( 2 ) ).to.equal( viewC );
+		} );
 	} );
 
 	describe( 'destroy()', () => {
@@ -216,8 +254,8 @@ describe( 'View', () => {
 		it( 'clears #_unboundChildren', () => {
 			const cached = view._unboundChildren;
 
-			view.addChildren( new View(), new View() );
-			expect( cached ).to.have.length.above( 1 );
+			view.addChildren( [ new View(), new View() ] );
+			expect( cached ).to.have.length.above( 2 );
 
 			return view.destroy().then( () => {
 				expect( cached ).to.have.length( 0 );
@@ -350,6 +388,4 @@ function createViewWithChildren() {
 	} );
 
 	setTestViewInstance();
-
-	view.addChildren( childA, childB );
 }


### PR DESCRIPTION
Closes #139.

I though I'll be able to deprecate `View#addChildren()` completely but I cannot. [There are cases](https://github.com/ckeditor/ckeditor5-ui/blob/t/139/src/button/buttonview.js#L194-L201) when child views are added after the template has been rendered and there's absolutely no way to detect whether they were registered or not.

Still, it should help developers avoid missing `addChildren()` in many places and simplify the code even further, which sounds good to me.