### PR TITLE
t/151: Silenced a warning in tests output

### DIFF
--- a/tests/template.js
+++ b/tests/template.js
@@ -1637,7 +1637,7 @@ describe( 'Template', () => {
 		} );
 
 		it( 'logs a warning if an element has already been rendered', () => {
-			const spy = testUtils.sinon.spy( log, 'warn' );
+			const spy = testUtils.sinon.stub( log, 'warn' );
 
 			const tpl = new Template( {
 				tag: 'p'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Silenced `template-extend-render` warning in tests output. Closes #151.
