### PR TITLE
t/162: Enable styling via class attribute in ListItemView.

### DIFF
--- a/src/list/listitemview.js
+++ b/src/list/listitemview.js
@@ -38,7 +38,8 @@ export default class ListItemView extends View {
 
 			attributes: {
 				class: [
-					'ck-list__item'
+					'ck-list__item',
+					bind.to( 'class' )
 				],
 				style: bind.to( 'style' ),
 				tabindex: bind.to( 'tabindex' )
@@ -67,6 +68,13 @@ export default class ListItemView extends View {
 		 *
 		 * @observable
 		 * @member {String} #style
+		 */
+
+		/**
+		 * (Optional) The additional class set on the {@link #element}.
+		 *
+		 * @observable
+		 * @member {String} #class
 		 */
 
 		/**

--- a/tests/list/listitemview.js
+++ b/tests/list/listitemview.js
@@ -27,6 +27,16 @@ describe( 'ListItemView', () => {
 	} );
 
 	describe( 'DOM bindings', () => {
+		describe( '"class" attribute', () => {
+			it( 'reacts on view#class', () => {
+				expect( view.element.classList ).to.have.length( 1 );
+
+				view.set( 'class', 'foo' );
+
+				expect( view.element.classList.contains( 'foo' ) ).to.be.true;
+			} );
+		} );
+
 		describe( '"style" attribute', () => {
 			it( 'reacts on view#style', () => {
 				expect( view.element.attributes.getNamedItem( 'style' ).value ).to.equal( 'foo' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Enabled styling via "class" attribute in ListItemView. Closes #162.