### PR TITLE
t/166: Allowed marking ListItemView active using the #isActive attribute

### DIFF
--- a/src/list/listitemview.js
+++ b/src/list/listitemview.js
@@ -39,7 +39,8 @@ export default class ListItemView extends View {
 			attributes: {
 				class: [
 					'ck-list__item',
-					bind.to( 'class' )
+					bind.to( 'class' ),
+					bind.if( 'isActive', 'ck-list__item_active' )
 				],
 				style: bind.to( 'style' ),
 				tabindex: bind.to( 'tabindex' )
@@ -75,6 +76,13 @@ export default class ListItemView extends View {
 		 *
 		 * @observable
 		 * @member {String} #class
+		 */
+
+		/**
+		 * (Optional) When set, it marks the item as active among the others.
+		 *
+		 * @observable
+		 * @member {Boolean} #isActive
 		 */
 
 		/**

--- a/tests/list/listitemview.js
+++ b/tests/list/listitemview.js
@@ -35,6 +35,14 @@ describe( 'ListItemView', () => {
 
 				expect( view.element.classList.contains( 'foo' ) ).to.be.true;
 			} );
+
+			it( 'reacts on view#isActive', () => {
+				expect( view.element.classList ).to.have.length( 1 );
+
+				view.set( 'isActive', true );
+
+				expect( view.element.classList.contains( 'ck-list__item_active' ) ).to.be.true;
+			} );
 		} );
 
 		describe( '"style" attribute', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Allowed marking ListItemView active using the #isActive attribute. Closes #166.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-ui/pull/163.
