### PR TITLE
t/206: BalloonPanelView should not be focusable

### DIFF
--- a/src/panel/balloon/balloonpanelview.js
+++ b/src/panel/balloon/balloonpanelview.js
@@ -134,10 +134,12 @@ export default class BalloonPanelView extends View {
 					top: bind.to( 'top', toPx ),
 					left: bind.to( 'left', toPx ),
 					maxWidth: bind.to( 'maxWidth', toPx )
-				},
+				}
+			},
 
-				// Make this element `focusable` to be available for adding to FocusTracker.
-				tabindex: -1
+			on: {
+				// https://github.com/ckeditor/ckeditor5-ui/issues/206
+				mousedown: bind.to( evt => evt.preventDefault() )
 			},
 
 			children: this.content

--- a/tests/panel/balloon/balloonpanelview.js
+++ b/tests/panel/balloon/balloonpanelview.js
@@ -35,7 +35,6 @@ describe( 'BalloonPanelView', () => {
 		it( 'should create element from template', () => {
 			expect( view.element.tagName ).to.equal( 'DIV' );
 			expect( view.element.classList.contains( 'ck-balloon-panel' ) ).to.true;
-			expect( view.element.getAttribute( 'tabindex' ) ).to.equal( '-1' );
 		} );
 
 		it( 'should set default values', () => {
@@ -48,6 +47,16 @@ describe( 'BalloonPanelView', () => {
 
 		it( 'creates view#content collection', () => {
 			expect( view.content ).to.be.instanceOf( ViewCollection );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-ui/issues/206
+		it( 'blocks native #mousedown event', () => {
+			const evt = new Event( 'mousedown' );
+			const spy = sinon.spy( evt, 'preventDefault' );
+
+			view.element.dispatchEvent( evt );
+
+			sinon.assert.calledOnce( spy );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: BalloonPanelView should not be focusable. Closes #206.

---

### Additional information

`BPV` has `@mixin ck-unselectable` enabled by default but CSS `user-select` does not affect focus.

Removing `tabindex="-1"` attribute disabled panel focus but it didn't prevent focus loss, so when clicked the panel didn't get focus but editor focus was lost, which was evident in editor-inline.

Only `preventDefault` of the `mousedown` event disabled focus properly and prevented focus loss.