### PR TITLE
t/205: Removed obsolete BalloonPanelView#maxWidth attibute, replaced by #className in the past

### DIFF
--- a/src/panel/balloon/balloonpanelview.js
+++ b/src/panel/balloon/balloonpanelview.js
@@ -98,13 +98,6 @@ export default class BalloonPanelView extends View {
 		this.set( 'className' );
 
 		/**
-		 * Max width of the balloon panel, as in CSS.
-		 *
-		 * @observable
-		 * @member {Number} #maxWidth
-		 */
-
-		/**
 		 * A callback that starts pining the panel when {@link #isVisible} gets
 		 * `true`. Used by {@link #pin}.
 		 *
@@ -133,8 +126,7 @@ export default class BalloonPanelView extends View {
 
 				style: {
 					top: bind.to( 'top', toPx ),
-					left: bind.to( 'left', toPx ),
-					maxWidth: bind.to( 'maxWidth', toPx )
+					left: bind.to( 'left', toPx )
 				}
 			},
 

--- a/tests/panel/balloon/balloonpanelview.js
+++ b/tests/panel/balloon/balloonpanelview.js
@@ -20,8 +20,6 @@ describe( 'BalloonPanelView', () => {
 	beforeEach( () => {
 		view = new BalloonPanelView();
 
-		view.set( 'maxWidth', 200 );
-
 		return view.init();
 	} );
 
@@ -94,14 +92,6 @@ describe( 'BalloonPanelView', () => {
 				view.left = 10;
 
 				expect( view.element.style.left ).to.equal( '10px' );
-			} );
-
-			it( 'should react on view#maxWidth', () => {
-				expect( view.element.style.maxWidth ).to.equal( '200px' );
-
-				view.maxWidth = 10;
-
-				expect( view.element.style.maxWidth ).to.equal( '10px' );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed obsolete BalloonPanelView#maxWidth attibute, replaced by #className in the past. Closes #205.
