### PR TITLE
t/238: The dropdown menu should not open using the keyboard when disabled

### DIFF
--- a/src/dropdown/dropdownview.js
+++ b/src/dropdown/dropdownview.js
@@ -148,7 +148,8 @@ export default class DropdownView extends View {
 
 		// Open the dropdown panel using the arrow down key, just like with return or space.
 		this.keystrokes.set( 'arrowdown', ( data, cancel ) => {
-			if ( !this.isOpen ) {
+			// Don't open if the dropdown is disabled or already open.
+			if ( this.isEnabled && !this.isOpen ) {
 				this.isOpen = true;
 				cancel();
 			}

--- a/tests/dropdown/dropdownview.js
+++ b/tests/dropdown/dropdownview.js
@@ -127,6 +127,8 @@ describe( 'DropdownView', () => {
 					stopPropagation: sinon.spy()
 				};
 
+				view.isEnabled = true;
+
 				view.isOpen = true;
 				view.keystrokes.press( keyEvtData );
 				sinon.assert.notCalled( keyEvtData.preventDefault );

--- a/tests/dropdown/dropdownview.js
+++ b/tests/dropdown/dropdownview.js
@@ -140,6 +140,22 @@ describe( 'DropdownView', () => {
 				expect( view.isOpen ).to.be.true;
 			} );
 
+			it( 'so "arrowdown" won\'t open the #panelView when #isEnabled is false', () => {
+				const keyEvtData = {
+					keyCode: keyCodes.arrowdown,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				view.isEnabled = false;
+				view.isOpen = false;
+
+				view.keystrokes.press( keyEvtData );
+				sinon.assert.notCalled( keyEvtData.preventDefault );
+				sinon.assert.notCalled( keyEvtData.stopPropagation );
+				expect( view.isOpen ).to.be.false;
+			} );
+
 			it( 'so "arrowright" is blocked', () => {
 				const keyEvtData = {
 					keyCode: keyCodes.arrowright,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The dropdown menu should not open using the keyboard when disabled. Closes #238.
