### PR TITLE
t/243: BalloonPanelView should prevent native #selectstart event

### DIFF
--- a/src/panel/balloon/balloonpanelview.js
+++ b/src/panel/balloon/balloonpanelview.js
@@ -134,7 +134,10 @@ export default class BalloonPanelView extends View {
 
 			on: {
 				// https://github.com/ckeditor/ckeditor5-ui/issues/206
-				mousedown: preventDefault( this )
+				mousedown: preventDefault( this ),
+
+				// https://github.com/ckeditor/ckeditor5-ui/issues/243
+				selectstart: bind.to( evt => evt.preventDefault() )
 			}
 		} );
 	}

--- a/tests/panel/balloon/balloonpanelview.js
+++ b/tests/panel/balloon/balloonpanelview.js
@@ -127,6 +127,17 @@ describe( 'BalloonPanelView', () => {
 				view.element.dispatchEvent( evt );
 				sinon.assert.calledOnce( spy );
 			} );
+
+			// https://github.com/ckeditor/ckeditor5-ui/issues/243
+			it( 'prevents default on #selectstart', () => {
+				const event = new Event( 'selectstart', { bubbles: true } );
+				const spy = sinon.spy( event, 'preventDefault' );
+				const child = document.createElement( 'div' );
+
+				view.element.appendChild( child );
+				child.dispatchEvent( event );
+				sinon.assert.calledOnce( spy );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: BalloonPanelView should prevent native #selectstart event. Closes #243.