### PR TITLE
T/248: Made UI destruction a repeatable process

### DIFF
--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -205,14 +205,4 @@ export default class ContextualBalloon extends Plugin {
 	_getBalloonPosition() {
 		return this._stack.values().next().value.position;
 	}
-
-	/**
-	 * @inheritDoc
-	 */
-	destroy() {
-		this.editor.ui.view.body.remove( this.view );
-		this.view.destroy();
-		this._stack.clear();
-		super.destroy();
-	}
 }

--- a/src/view.js
+++ b/src/view.js
@@ -14,7 +14,6 @@ import DomEmmiterMixin from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import log from '@ckeditor/ckeditor5-utils/src/log';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
 
 /**
@@ -101,16 +100,6 @@ export default class View {
 		 * @member {module:ui/viewcollection~ViewCollection}
 		 */
 		this._unboundChildren = this.createCollection();
-
-		/**
-		 * Specifies whether the instance was destroyed using {@link #destroy} method
-		 * in the past.
-		 *
-		 * @private
-		 * @readonly
-		 * @member {Boolean}
-		 */
-		this._wasDestroyed = false;
 
 		// Pass parent locale to its children.
 		this._viewCollections.on( 'add', ( evt, collection ) => {
@@ -318,23 +307,9 @@ export default class View {
 	 * @returns {Promise} A Promise resolved when the destruction process is finished.
 	 */
 	destroy() {
-		/**
-		 * The view has already been destroyed. If you see this warning, it means that some piece
-		 * of code attempted to destroy it again, which usually may (but not must) be a symptom of
-		 * a broken destruction logic in a code that uses this view instance.
-		 *
-		 * @error ui-view-destroy-again
-		 */
-		if ( this._wasDestroyed ) {
-			log.warn( 'ui-view-destroy-again: The view has already been destroyed.', { view: this } );
-		}
-
 		this.stopListening();
 
-		return Promise.all( this._viewCollections.map( c => c.destroy() ) )
-			.then( () => {
-				this._wasDestroyed = true;
-			} );
+		return Promise.all( this._viewCollections.map( c => c.destroy() ) );
 	}
 
 	/**

--- a/src/view.js
+++ b/src/view.js
@@ -14,6 +14,7 @@ import DomEmmiterMixin from '@ckeditor/ckeditor5-utils/src/dom/emittermixin';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
 
 /**
@@ -100,6 +101,16 @@ export default class View {
 		 * @member {module:ui/viewcollection~ViewCollection}
 		 */
 		this._unboundChildren = this.createCollection();
+
+		/**
+		 * Specifies whether the instance was destroyed using {@link #destroy} method
+		 * in the past.
+		 *
+		 * @private
+		 * @readonly
+		 * @member {Boolean}
+		 */
+		this._wasDestroyed = false;
 
 		// Pass parent locale to its children.
 		this._viewCollections.on( 'add', ( evt, collection ) => {
@@ -307,15 +318,22 @@ export default class View {
 	 * @returns {Promise} A Promise resolved when the destruction process is finished.
 	 */
 	destroy() {
+		/**
+		 * The view has already been destroyed. If you see this warning, it means that some piece
+		 * of code attempted to destroy it again, which usually may (but not must) be a symptom of
+		 * a broken destruction logic in a code that uses this view instance.
+		 *
+		 * @error ui-view-destroy-again
+		 */
+		if ( this._wasDestroyed ) {
+			log.warn( 'ui-view-destroy-again: The view has already been destroyed.', { view: this } );
+		}
+
 		this.stopListening();
 
 		return Promise.all( this._viewCollections.map( c => c.destroy() ) )
 			.then( () => {
-				this._unboundChildren.clear();
-				this._viewCollections.clear();
-
-				this.element = this.template = this.locale = this.t =
-					this._viewCollections = this._unboundChildren = null;
+				this._wasDestroyed = true;
 			} );
 	}
 

--- a/tests/editableui/editableuiview.js
+++ b/tests/editableui/editableuiview.js
@@ -85,6 +85,16 @@ describe( 'EditableUIView', () => {
 			} );
 		} );
 
+		it( 'can be called multiple times', done => {
+			expect( () => {
+				view.destroy().then( () => {
+					return view.destroy().then( () => {
+						done();
+					} );
+				} );
+			} ).to.not.throw();
+		} );
+
 		describe( 'when #editableElement as an argument', () => {
 			it( 'reverts contentEditable property of editableElement (was false)', () => {
 				editableElement = document.createElement( 'div' );

--- a/tests/editorui/editoruiview.js
+++ b/tests/editorui/editoruiview.js
@@ -51,5 +51,15 @@ describe( 'EditorUIView', () => {
 				expect( el.parentNode ).to.be.null;
 			} );
 		} );
+
+		it( 'can be called multiple times', done => {
+			expect( () => {
+				view.destroy().then( () => {
+					return view.destroy().then( () => {
+						done();
+					} );
+				} );
+			} ).to.not.throw();
+		} );
 	} );
 } );

--- a/tests/panel/balloon/contextualballoon.js
+++ b/tests/panel/balloon/contextualballoon.js
@@ -352,11 +352,17 @@ describe( 'ContextualBalloon', () => {
 	} );
 
 	describe( 'destroy()', () => {
-		it( 'should remove balloon panel view from editor body collection and clear stack', () => {
+		it( 'can be called multiple times', () => {
+			expect( () => {
+				balloon.destroy();
+				balloon.destroy();
+			} ).to.not.throw();
+		} );
+
+		it( 'should not touch the DOM', () => {
 			balloon.destroy();
 
-			expect( editor.ui.view.body.getIndex( balloon.view ) ).to.equal( -1 );
-			expect( balloon.visibleView ).to.null;
+			expect( editor.ui.view.body.getIndex( balloon.view ) ).to.not.equal( -1 );
 		} );
 	} );
 } );

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -291,6 +291,13 @@ describe( 'ContextualToolbar', () => {
 	} );
 
 	describe( 'destroy()', () => {
+		it( 'can be called multiple times', () => {
+			expect( () => {
+				contextualToolbar.destroy();
+				contextualToolbar.destroy();
+			} ).to.not.throw();
+		} );
+
 		it( 'should not fire `_selectionChangeDebounced` after plugin destroy', done => {
 			const spy = sandbox.spy();
 

--- a/tests/toolbar/sticky/stickytoolbarview.js
+++ b/tests/toolbar/sticky/stickytoolbarview.js
@@ -178,6 +178,16 @@ describe( 'StickyToolbarView', () => {
 			expect( view.destroy() ).to.be.instanceof( Promise );
 		} );
 
+		it( 'can be called multiple times', done => {
+			expect( () => {
+				view.destroy().then( () => {
+					return view.destroy().then( () => {
+						done();
+					} );
+				} );
+			} ).to.not.throw();
+		} );
+
 		it( 'calls destroy on parent class', () => {
 			const spy = testUtils.sinon.spy( ToolbarView.prototype, 'destroy' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Made the UI destruction a fail–safe, repeatable process. Closes #248.