### PR TITLE
t/225: Made the UI component initialisation and destruction processes synchronous

### DIFF
--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -207,8 +207,6 @@ export default class ButtonView extends View {
 	 * @inheritDoc
 	 */
 	init() {
-		let promise = Promise.resolve();
-
 		if ( this.icon && !this.iconView ) {
 			const iconView = this.iconView = new IconView();
 
@@ -217,10 +215,10 @@ export default class ButtonView extends View {
 			this.element.insertBefore( iconView.element, this.element.firstChild );
 
 			// Make sure the icon view will be destroyed along with button.
-			promise = promise.then( () => this.addChildren( iconView ) );
+			this.addChildren( iconView );
 		}
 
-		return promise.then( () => super.init() );
+		super.init();
 	}
 
 	/**

--- a/src/dropdown/dropdownview.js
+++ b/src/dropdown/dropdownview.js
@@ -138,7 +138,7 @@ export default class DropdownView extends View {
 		this.keystrokes.set( 'arrowleft', closeDropdown );
 		this.keystrokes.set( 'esc', closeDropdown );
 
-		return super.init();
+		super.init();
 	}
 
 	/**

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -78,8 +78,6 @@ export default class EditableUIView extends View {
 	/**
 	 * Initializes the view by either applying the {@link #template} to the existing
 	 * {@link #editableElement} or assigning {@link #element} as {@link #editableElement}.
-	 *
-	 * @returns {Promise}
 	 */
 	init() {
 		if ( this.externalElement ) {
@@ -88,7 +86,7 @@ export default class EditableUIView extends View {
 			this.editableElement = this.element;
 		}
 
-		return super.init();
+		super.init();
 	}
 
 	/**
@@ -99,6 +97,6 @@ export default class EditableUIView extends View {
 			this.template.revert( this.externalElement );
 		}
 
-		return super.destroy();
+		super.destroy();
 	}
 }

--- a/src/editorui/editoruiview.js
+++ b/src/editorui/editoruiview.js
@@ -47,9 +47,8 @@ export default class EditorUIView extends View {
 	 * @inheritDoc
 	 */
 	init() {
-		return Promise.resolve()
-			.then( () => this._renderBodyCollection() )
-			.then( () => super.init() );
+		this._renderBodyCollection();
+		super.init();
 	}
 
 	/**

--- a/src/list/listview.js
+++ b/src/list/listview.js
@@ -98,7 +98,7 @@ export default class ListView extends View {
 		// Start listening for the keystrokes coming from #element.
 		this.keystrokes.listenTo( this.element );
 
-		return super.init();
+		super.init();
 	}
 
 	/**

--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -60,7 +60,7 @@ export default class ContextualBalloon extends Plugin {
 		this.editor.ui.focusTracker.add( this.view.element );
 
 		// Add balloon panel view to editor `body` collection and wait until view will be ready.
-		return this.editor.ui.view.body.add( this.view );
+		this.editor.ui.view.body.add( this.view );
 	}
 
 	/**
@@ -92,7 +92,6 @@ export default class ContextualBalloon extends Plugin {
 	 * @param {module:ui/view~View} [data.view] Content of the balloon.
 	 * @param {module:utils/dom/position~Options} [data.position] Positioning options.
 	 * @param {String} [data.balloonClassName] Additional css class for {@link #view} added when given view is visible.
-	 * @returns {Promise} A Promise resolved when the child {@link module:ui/view~View#init} is done.
 	 */
 	add( data ) {
 		if ( this.hasView( data.view ) ) {
@@ -112,8 +111,9 @@ export default class ContextualBalloon extends Plugin {
 
 		// Add new view to the stack.
 		this._stack.set( data.view, data );
+
 		// And display it.
-		return this._show( data );
+		this._show( data );
 	}
 
 	/**
@@ -122,7 +122,6 @@ export default class ContextualBalloon extends Plugin {
 	 * When there is no view in the stack then balloon will hide.
 	 *
 	 * @param {module:ui/view~View} view A view to be removed from the balloon.
-	 * @returns {Promise} A Promise resolved when the preceding view is ready.
 	 */
 	remove( view ) {
 		if ( !this.hasView( view ) ) {
@@ -133,9 +132,6 @@ export default class ContextualBalloon extends Plugin {
 			 */
 			throw new CKEditorError( 'contextualballoon-remove-view-not-exist: Cannot remove configuration of not existing view.' );
 		}
-
-		// A Promise resolved when the preceding view is ready.
-		let promise = Promise.resolve();
 
 		// When visible view is being removed.
 		if ( this.visibleView === view ) {
@@ -151,7 +147,7 @@ export default class ContextualBalloon extends Plugin {
 			// If it is some other view.
 			if ( last ) {
 				// Just show it.
-				promise = this._show( last );
+				this._show( last );
 			} else {
 				// Hide the balloon panel.
 				this.view.hide();
@@ -160,8 +156,6 @@ export default class ContextualBalloon extends Plugin {
 			// Just remove given view from the stack.
 			this._stack.delete( view );
 		}
-
-		return promise;
 	}
 
 	/**
@@ -190,9 +184,8 @@ export default class ContextualBalloon extends Plugin {
 	_show( { view, balloonClassName = '' } ) {
 		this.view.className = balloonClassName;
 
-		return this.view.content.add( view ).then( () => {
-			this.view.pin( this._getBalloonPosition() );
-		} );
+		this.view.content.add( view );
+		this.view.pin( this._getBalloonPosition() );
 	}
 
 	/**

--- a/src/toolbar/sticky/stickytoolbarview.js
+++ b/src/toolbar/sticky/stickytoolbarview.js
@@ -175,9 +175,8 @@ export default class StickyToolbarView extends ToolbarView {
 	 * Destroys the toolbar and removes the {@link #_elementPlaceholder}.
 	 */
 	destroy() {
-		return super.destroy().then( () => {
-			this._elementPlaceholder.remove();
-		} );
+		super.destroy();
+		this._elementPlaceholder.remove();
 	}
 
 	/**

--- a/src/toolbar/toolbarview.js
+++ b/src/toolbar/toolbarview.js
@@ -103,7 +103,7 @@ export default class ToolbarView extends View {
 		// Start listening for the keystrokes coming from #element.
 		this.keystrokes.listenTo( this.element );
 
-		return super.init();
+		super.init();
 	}
 
 	/**
@@ -119,18 +119,17 @@ export default class ToolbarView extends View {
 	 *
 	 * @param {Array} config The toolbar config.
 	 * @param {module:ui/componentfactory~ComponentFactory} factory A factory producing toolbar items.
-	 * @returns {Promise} A promise resolved when created toolbar items are initialized.
 	 */
 	fillFromConfig( config, factory ) {
 		if ( !config ) {
-			return Promise.resolve();
+			return;
 		}
 
-		return Promise.all( config.map( name => {
+		config.map( name => {
 			const component = name == '|' ? new ToolbarSeparatorView() : factory.create( name );
 
-			return this.items.add( component );
-		} ) );
+			this.items.add( component );
+		} );
 	}
 }
 

--- a/src/view.js
+++ b/src/view.js
@@ -43,10 +43,10 @@ import isIterable from '@ckeditor/ckeditor5-utils/src/isiterable';
  *
  *		const view = new SampleView( locale );
  *
- *		view.init().then( () => {
- *			// Will append <p class="foo">Hello<b>world</b></p>
- *			document.body.appendChild( view.element );
- *		} );
+ *		view.init();
+ *
+ *		// Will append <p class="foo">Hello<b>world</b></p>
+ *		document.body.appendChild( view.element );
  *
  * @mixes module:utils/observablemixin~ObservableMixin
  */
@@ -190,14 +190,14 @@ export default class View {
 	 *		const view = new SampleView( locale );
 	 *		const anotherView = new AnotherSampleView( locale );
 	 *
-	 *		view.init().then( () => {
-	 *			// Will append <p></p>
-	 *			document.body.appendChild( view.element );
+	 *		view.init();
 	 *
-	 *			// `anotherView` becomes a child of the view, which is reflected in DOM
-	 *			// <p><anotherView#element></p>
-	 *			view.items.add( anotherView );
-	 *		} );
+	 *		// Will append <p></p>
+	 *		document.body.appendChild( view.element );
+	 *
+	 *		// `anotherView` becomes a child of the view, which is reflected in DOM
+	 *		// <p><anotherView#element></p>
+	 *		view.items.add( anotherView );
 	 *
 	 * @returns {module:ui/viewcollection~ViewCollection} A new collection of view instances.
 	 */
@@ -237,10 +237,10 @@ export default class View {
 	 *
 	 *		const view = new SampleView( locale );
 	 *
-	 *		view.init().then( () => {
-	 *			// Will append <p><childA#element><b></b><childB#element></p>
-	 *			document.body.appendChild( view.element );
-	 *		} );
+	 *		view.init();
+	 *
+	 *		// Will append <p><childA#element><b></b><childB#element></p>
+	 *		document.body.appendChild( view.element );
 	 *
 	 * **Note**: There's no need to add child views if they're used in the
 	 * {@link #template} explicitly:
@@ -265,20 +265,17 @@ export default class View {
 	 *		}
 	 *
 	 * @param {module:ui/view~View|Iterable.<module:ui/view~View>} children Children views to be registered.
-	 * @returns {Promise}
 	 */
 	addChildren( children ) {
 		if ( !isIterable( children ) ) {
 			children = [ children ];
 		}
 
-		return Promise.all( children.map( c => this._unboundChildren.add( c ) ) );
+		children.map( c => this._unboundChildren.add( c ) );
 	}
 
 	/**
 	 * Initializes the view and child views located in {@link #_viewCollections}.
-	 *
-	 * @returns {Promise} A Promise resolved when the initialization process is finished.
 	 */
 	init() {
 		if ( this.ready ) {
@@ -290,26 +287,20 @@ export default class View {
 			throw new CKEditorError( 'ui-view-init-reinit: This View has already been initialized.' );
 		}
 
-		return Promise.resolve()
-			// Initialize collections in #_viewCollections.
-			.then( () => {
-				return Promise.all( this._viewCollections.map( c => c.init() ) );
-			} )
-			// Spread the word that this view is ready!
-			.then( () => {
-				this.ready = true;
-			} );
+		// Initialize collections in #_viewCollections.
+		this._viewCollections.map( c => c.init() );
+
+		// Spread the word that this view is ready!
+		this.ready = true;
 	}
 
 	/**
-	 * Destroys the view instance and child views located in {@link #_viewCollections}.
-	 *
-	 * @returns {Promise} A Promise resolved when the destruction process is finished.
+f	 * Destroys the view instance and child views located in {@link #_viewCollections}.
 	 */
 	destroy() {
 		this.stopListening();
 
-		return Promise.all( this._viewCollections.map( c => c.destroy() ) );
+		this._viewCollections.map( c => c.destroy() );
 	}
 
 	/**

--- a/src/view.js
+++ b/src/view.js
@@ -295,7 +295,7 @@ export default class View {
 	}
 
 	/**
-f	 * Destroys the view instance and child views located in {@link #_viewCollections}.
+	 * Destroys the view instance and child views located in {@link #_viewCollections}.
 	 */
 	destroy() {
 		this.stopListening();

--- a/tests/_utils-tests/utils.js
+++ b/tests/_utils-tests/utils.js
@@ -9,40 +9,30 @@ import testUtils from '../../tests/_utils/utils';
 
 describe( 'utils', () => {
 	describe( 'createTestUIView', () => {
-		it( 'returns a promise', () => {
-			expect( testUtils.createTestUIView() ).to.be.instanceof( Promise );
-		} );
-
 		describe( 'view instance', () => {
 			it( 'comes with a view', () => {
-				const promise = testUtils.createTestUIView();
+				const view = testUtils.createTestUIView();
 
-				return promise.then( view => {
-					expect( view.element ).to.equal( document.body );
-				} );
+				expect( view.element ).to.equal( document.body );
 			} );
 
 			it( 'creates collections and regions', () => {
-				const promise = testUtils.createTestUIView( {
+				const view = testUtils.createTestUIView( {
 					foo: el => el.firstChild,
 					bar: el => el.lastChild,
 				} );
 
-				return promise.then( view => {
-					expect( view.foo._parentElement ).to.equal( document.body.firstChild );
-					expect( view.bar._parentElement ).to.equal( document.body.lastChild );
-				} );
+				expect( view.foo._parentElement ).to.equal( document.body.firstChild );
+				expect( view.bar._parentElement ).to.equal( document.body.lastChild );
 			} );
 
 			it( 'is ready', () => {
-				const promise = testUtils.createTestUIView( {
+				const view = testUtils.createTestUIView( {
 					foo: el => el.firstChild,
 					bar: el => el.lastChild,
 				} );
 
-				return promise.then( view => {
-					expect( view.ready ).to.be.true;
-				} );
+				expect( view.ready ).to.be.true;
 			} );
 		} );
 	} );

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -50,9 +50,9 @@ const utils = {
 
 		const view = new TestUIView();
 
-		return view.init().then( () => {
-			return view;
-		} );
+		view.init();
+
+		return view;
 	}
 };
 

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -225,29 +225,27 @@ describe( 'ButtonView', () => {
 			view = new ButtonView( locale );
 			view.icon = 'foo';
 
-			return view.init().then( () => {
-				expect( view.element.childNodes ).to.have.length( 2 );
-				expect( view.element.childNodes[ 0 ] ).to.equal( view.iconView.element );
+			view.init();
+			expect( view.element.childNodes ).to.have.length( 2 );
+			expect( view.element.childNodes[ 0 ] ).to.equal( view.iconView.element );
 
-				expect( view.iconView ).to.instanceOf( IconView );
-				expect( view.iconView.content ).to.equal( 'foo' );
+			expect( view.iconView ).to.instanceOf( IconView );
+			expect( view.iconView.content ).to.equal( 'foo' );
 
-				view.icon = 'bar';
-				expect( view.iconView.content ).to.equal( 'bar' );
-			} );
+			view.icon = 'bar';
+			expect( view.iconView.content ).to.equal( 'bar' );
 		} );
 
 		it( 'is destroyed with the view', () => {
 			view = new ButtonView( locale );
 			view.icon = 'foo';
 
-			return view.init().then( () => {
-				const spy = sinon.spy( view.iconView, 'destroy' );
+			view.init();
 
-				return view.destroy().then( () => {
-					sinon.assert.calledOnce( spy );
-				} );
-			} );
+			const spy = sinon.spy( view.iconView, 'destroy' );
+
+			view.destroy();
+			sinon.assert.calledOnce( spy );
 		} );
 	} );
 

--- a/tests/dropdown/dropdownview.js
+++ b/tests/dropdown/dropdownview.js
@@ -100,10 +100,9 @@ describe( 'DropdownView', () => {
 
 			const spy = sinon.spy( view.keystrokes, 'listenTo' );
 
-			return view.init().then( () => {
-				sinon.assert.calledOnce( spy );
-				sinon.assert.calledWithExactly( spy, view.element );
-			} );
+			view.init();
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, view.element );
 		} );
 
 		it( 'adds #element to #focusTracker', () => {
@@ -113,10 +112,9 @@ describe( 'DropdownView', () => {
 
 			const spy = sinon.spy( view.focusTracker, 'add' );
 
-			return view.init().then( () => {
-				sinon.assert.calledOnce( spy );
-				sinon.assert.calledWithExactly( spy, view.element );
-			} );
+			view.init();
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, view.element );
 		} );
 
 		describe( 'activates keyboard navigation for the dropdown', () => {

--- a/tests/dropdown/list/createlistdropdown.js
+++ b/tests/dropdown/list/createlistdropdown.js
@@ -25,9 +25,9 @@ describe( 'createListDropdown', () => {
 			label: 'foo'
 		} );
 
-		return ( view = createListDropdown( model, locale ) ).init().then( () => {
-			document.body.appendChild( view.element );
-		} );
+		view = createListDropdown( model, locale );
+		view.init();
+		document.body.appendChild( view.element );
 	} );
 
 	describe( 'constructor()', () => {

--- a/tests/dropdown/manual/dropdown.js
+++ b/tests/dropdown/manual/dropdown.js
@@ -14,9 +14,8 @@ import createListDropdown from '../../../src/dropdown/list/createlistdropdown';
 import '@ckeditor/ckeditor5-theme-lark/theme/theme.scss';
 
 function renderInto( selector, view ) {
-	view.init().then( () => {
-		document.querySelector( selector ).appendChild( view.element );
-	} );
+	view.init();
+	document.querySelector( selector ).appendChild( view.element );
 }
 
 function testEmpty() {

--- a/tests/editableui/editableuiview.js
+++ b/tests/editableui/editableuiview.js
@@ -32,22 +32,20 @@ describe( 'EditableUIView', () => {
 		it( 'renders element from template when no editableElement', () => {
 			view = new EditableUIView( locale );
 
-			return view.init().then( () => {
-				expect( view.element ).to.equal( view.editableElement );
-				expect( view.element.classList.contains( 'ck-editor__editable' ) ).to.be.true;
-				expect( view.externalElement ).to.be.undefined;
-			} );
+			view.init();
+			expect( view.element ).to.equal( view.editableElement );
+			expect( view.element.classList.contains( 'ck-editor__editable' ) ).to.be.true;
+			expect( view.externalElement ).to.be.undefined;
 		} );
 
 		it( 'accepts editableElement as an argument', () => {
 			view = new EditableUIView( locale, editableElement );
 
-			return view.init().then( () => {
-				expect( view.element ).to.equal( editableElement );
-				expect( view.element ).to.equal( view.editableElement );
-				expect( view.element.classList.contains( 'ck-editor__editable' ) ).to.be.true;
-				expect( view.externalElement ).to.equal( editableElement );
-			} );
+			view.init();
+			expect( view.element ).to.equal( editableElement );
+			expect( view.element ).to.equal( view.editableElement );
+			expect( view.element.classList.contains( 'ck-editor__editable' ) ).to.be.true;
+			expect( view.externalElement ).to.equal( editableElement );
 		} );
 	} );
 
@@ -80,18 +78,14 @@ describe( 'EditableUIView', () => {
 		it( 'calls super#destroy()', () => {
 			const spy = testUtils.sinon.spy( View.prototype, 'destroy' );
 
-			return view.destroy().then( () => {
-				sinon.assert.calledOnce( spy );
-			} );
+			view.destroy();
+			sinon.assert.calledOnce( spy );
 		} );
 
-		it( 'can be called multiple times', done => {
+		it( 'can be called multiple times', () => {
 			expect( () => {
-				view.destroy().then( () => {
-					return view.destroy().then( () => {
-						done();
-					} );
-				} );
+				view.destroy();
+				view.destroy();
 			} ).to.not.throw();
 		} );
 
@@ -102,14 +96,10 @@ describe( 'EditableUIView', () => {
 
 				view = new EditableUIView( locale, editableElement );
 
-				return view.init()
-					.then( () => {
-						expect( editableElement.contentEditable ).to.equal( 'true' );
-					} )
-					.then( () => view.destroy() )
-					.then( () => {
-						expect( editableElement.contentEditable ).to.equal( 'false' );
-					} );
+				view.init();
+				expect( editableElement.contentEditable ).to.equal( 'true' );
+				view.destroy();
+				expect( editableElement.contentEditable ).to.equal( 'false' );
 			} );
 
 			it( 'reverts contentEditable property of editableElement (was true)', () => {
@@ -118,14 +108,10 @@ describe( 'EditableUIView', () => {
 
 				view = new EditableUIView( locale, editableElement );
 
-				return view.init()
-					.then( () => {
-						expect( editableElement.contentEditable ).to.equal( 'true' );
-					} )
-					.then( () => view.destroy() )
-					.then( () => {
-						expect( editableElement.contentEditable ).to.equal( 'true' );
-					} );
+				view.init();
+				expect( editableElement.contentEditable ).to.equal( 'true' );
+				view.destroy();
+				expect( editableElement.contentEditable ).to.equal( 'true' );
 			} );
 		} );
 	} );

--- a/tests/editorui/editoruiview.js
+++ b/tests/editorui/editoruiview.js
@@ -47,18 +47,14 @@ describe( 'EditorUIView', () => {
 		it( 'removes the body region container', () => {
 			const el = view._bodyCollectionContainer;
 
-			return view.destroy().then( () => {
-				expect( el.parentNode ).to.be.null;
-			} );
+			view.destroy();
+			expect( el.parentNode ).to.be.null;
 		} );
 
-		it( 'can be called multiple times', done => {
+		it( 'can be called multiple times', () => {
 			expect( () => {
-				view.destroy().then( () => {
-					return view.destroy().then( () => {
-						done();
-					} );
-				} );
+				view.destroy();
+				view.destroy();
 			} ).to.not.throw();
 		} );
 	} );

--- a/tests/list/listview.js
+++ b/tests/list/listview.js
@@ -64,10 +64,9 @@ describe( 'ListView', () => {
 
 			const spy = sinon.spy( view.keystrokes, 'listenTo' );
 
-			return view.init().then( () => {
-				sinon.assert.calledOnce( spy );
-				sinon.assert.calledWithExactly( spy, view.element );
-			} );
+			view.init();
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, view.element );
 		} );
 
 		describe( 'activates keyboard navigation for the list', () => {

--- a/tests/manual/contextualballoon/contextualballoon.js
+++ b/tests/manual/contextualballoon/contextualballoon.js
@@ -153,8 +153,6 @@ class PluginGeneric extends Plugin {
 
 			return toolbar.fillFromConfig( this.buttons, this.editor.ui.componentFactory );
 		}
-
-		return Promise.resolve();
 	}
 
 	_showPanel() {

--- a/tests/manual/stickytoolbarview/stickytoolbarview.js
+++ b/tests/manual/stickytoolbarview/stickytoolbarview.js
@@ -3,29 +3,22 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals console:false */
-
 import testUtils from '../../../tests/_utils/utils';
 import StickyToolbarView from '../../../src/toolbar/sticky/stickytoolbarview';
 
 import '@ckeditor/ckeditor5-theme-lark/theme/theme.scss';
 
-testUtils.createTestUIView( {
+const ui = testUtils.createTestUIView( {
 	top: '.ck-editor__top'
-} )
-.then( ui => {
-	createToolbar( ui.top );
-} )
-.catch( err => {
-	console.error( err.stack );
 } );
+
+createToolbar( ui.top );
 
 function createToolbar( collection ) {
 	const toolbar = new StickyToolbarView();
 
 	toolbar.limiterElement = collection._parentElement.parentNode;
 
-	collection.add( toolbar ).then( () => {
-		toolbar.isActive = true;
-	} );
+	collection.add( toolbar );
+	toolbar.isActive = true;
 }

--- a/tests/manual/tickets/126/1.js
+++ b/tests/manual/tickets/126/1.js
@@ -13,11 +13,11 @@ window.createPanel = selector => {
 	const view = new BalloonPanelView();
 
 	view.element.innerHTML = `Parent of this panel has position:${ selector }.`;
-	view.init().then( () => {
-		document.querySelector( `#${ selector }-container` ).appendChild( view.element );
+	view.init();
 
-		view.attachTo( {
-			target: document.querySelector( `#anchor-${ selector }` )
-		} );
+	document.querySelector( `#${ selector }-container` ).appendChild( view.element );
+
+	view.attachTo( {
+		target: document.querySelector( `#anchor-${ selector }` )
 	} );
 };

--- a/tests/manual/tickets/170/1.js
+++ b/tests/manual/tickets/170/1.js
@@ -25,11 +25,10 @@ ClassicEditor.create( document.querySelector( '#editor-attach' ), {
 
 	editor.ui.view.element.querySelector( '.ck-editor__editable' ).scrollTop = 360;
 
-	panel.init().then( () => {
-		panel.attachTo( {
-			target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
-			limiter: editor.ui.view.editableElement
-		} );
+	panel.init();
+	panel.attachTo( {
+		target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
+		limiter: editor.ui.view.editableElement
 	} );
 
 	window.attachEditor = editor;

--- a/tests/manual/tickets/170/1.js
+++ b/tests/manual/tickets/170/1.js
@@ -51,11 +51,10 @@ ClassicEditor.create( document.querySelector( '#editor-stick' ), {
 
 	editor.ui.view.element.querySelector( '.ck-editor__editable' ).scrollTop = 360;
 
-	panel.init().then( () => {
-		panel.pin( {
-			target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
-			limiter: editor.ui.view.editableElement
-		} );
+	panel.init();
+	panel.pin( {
+		target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
+		limiter: editor.ui.view.editableElement
 	} );
 
 	window.stickEditor = editor;

--- a/tests/panel/balloon/balloonpanelview.js
+++ b/tests/panel/balloon/balloonpanelview.js
@@ -113,9 +113,8 @@ describe( 'BalloonPanelView', () => {
 
 				const button = new ButtonView( { t() {} } );
 
-				return view.content.add( button ).then( () => {
-					expect( view.element.childNodes.length ).to.equal( 1 );
-				} );
+				view.content.add( button );
+				expect( view.element.childNodes.length ).to.equal( 1 );
 			} );
 		} );
 
@@ -565,15 +564,14 @@ describe( 'BalloonPanelView', () => {
 
 				sinon.assert.calledOnce( attachToSpy );
 
-				return view.destroy().then( () => {
-					view = null;
+				view.destroy();
+				view = null;
 
-					window.dispatchEvent( new Event( 'resize' ) );
-					window.dispatchEvent( new Event( 'scroll' ) );
+				window.dispatchEvent( new Event( 'resize' ) );
+				window.dispatchEvent( new Event( 'scroll' ) );
 
-					// Still once.
-					sinon.assert.calledOnce( attachToSpy );
-				} );
+				// Still once.
+				sinon.assert.calledOnce( attachToSpy );
 			} );
 
 			it( 'should set document.body as the default limiter', () => {

--- a/tests/panel/balloon/contextualballoon.js
+++ b/tests/panel/balloon/contextualballoon.js
@@ -10,7 +10,7 @@ import View from '../../../src/view';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-/* global document, Event, setTimeout */
+/* global document, Event */
 
 describe( 'ContextualBalloon', () => {
 	let editor, editorElement, balloon, viewA, viewB;
@@ -35,13 +35,12 @@ describe( 'ContextualBalloon', () => {
 			viewB = new View();
 
 			// Add viewA to the pane and init viewB.
-			return Promise.all( [
-				balloon.add( {
-					view: viewA,
-					position: { target: 'fake' }
-				} ),
-				viewB.init(),
-			] );
+			balloon.add( {
+				view: viewA,
+				position: { target: 'fake' }
+			} );
+
+			viewB.init();
 		} );
 	} );
 
@@ -104,33 +103,6 @@ describe( 'ContextualBalloon', () => {
 	} );
 
 	describe( 'add()', () => {
-		it( 'should return promise resolved when view is ready', done => {
-			const clock = sinon.useFakeTimers();
-
-			const view = {
-				init: () => {
-					return new Promise( resolve => {
-						setTimeout( () => {
-							resolve();
-						}, 10 );
-					} );
-				},
-				destroy: () => {}
-			};
-
-			const result = balloon.add( {
-				view,
-				position: { target: 'fake' }
-			} );
-
-			expect( result ).to.instanceof( Promise );
-
-			result.then( done );
-
-			clock.tick( 11 );
-			clock.restore();
-		} );
-
 		it( 'should add view to the stack and display in balloon attached using given position options', () => {
 			expect( balloon.view.content.length ).to.equal( 1 );
 			expect( balloon.view.content.get( 0 ) ).to.deep.equal( viewA );
@@ -162,20 +134,19 @@ describe( 'ContextualBalloon', () => {
 		} );
 
 		it( 'should keep balloon at the same position after adding next view', () => {
-			return balloon.add( {
+			balloon.add( {
 				view: viewB,
 				position: { target: 'other' }
-			} )
-			.then( () => {
-				expect( balloon.view.pin.calledTwice ).to.true;
+			} );
 
-				expect( balloon.view.pin.firstCall.args[ 0 ] ).to.deep.equal( {
-					target: 'fake'
-				} );
+			expect( balloon.view.pin.calledTwice ).to.true;
 
-				expect( balloon.view.pin.secondCall.args[ 0 ] ).to.deep.equal( {
-					target: 'fake'
-				} );
+			expect( balloon.view.pin.firstCall.args[ 0 ] ).to.deep.equal( {
+				target: 'fake'
+			} );
+
+			expect( balloon.view.pin.secondCall.args[ 0 ] ).to.deep.equal( {
+				target: 'fake'
 			} );
 		} );
 
@@ -221,10 +192,6 @@ describe( 'ContextualBalloon', () => {
 	} );
 
 	describe( 'remove()', () => {
-		it( 'should return promise', () => {
-			expect( balloon.remove( viewA ) ).to.instanceof( Promise );
-		} );
-
 		it( 'should remove given view and hide balloon when there is no other view to display', () => {
 			balloon.view.isVisible = true;
 
@@ -243,36 +210,6 @@ describe( 'ContextualBalloon', () => {
 			balloon.remove( viewB );
 
 			expect( balloon.visibleView ).to.equal( viewA );
-		} );
-
-		it( 'should wait for init of preceding view when was is not ready', done => {
-			const clock = sinon.useFakeTimers();
-
-			const view = {
-				init: () => {
-					return new Promise( resolve => {
-						setTimeout( () => {
-							resolve();
-						}, 10 );
-					} );
-				},
-				destroy: () => {}
-			};
-
-			balloon.add( {
-				view,
-				position: { target: 'fake' }
-			} );
-
-			balloon.add( {
-				view: viewB,
-				position: { target: 'fake' }
-			} );
-
-			balloon.remove( viewB ).then( done );
-
-			clock.tick( 11 );
-			clock.restore();
 		} );
 
 		it( 'should remove given view from the stack when view is not visible', () => {

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -43,7 +43,7 @@ describe( 'ContextualToolbar', () => {
 			// Focus the engine.
 			editor.editing.view.isFocused = true;
 
-			return contextualToolbar.toolbarView.init();
+			contextualToolbar.toolbarView.init();
 		} );
 	} );
 
@@ -141,38 +141,28 @@ describe( 'ContextualToolbar', () => {
 			editor.editing.view.isFocused = true;
 		} );
 
-		it( 'should return a promise', () => {
-			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
-
-			const returned = contextualToolbar._showPanel();
-
-			expect( returned ).to.instanceof( Promise );
-
-			return returned;
-		} );
-
 		it( 'should add #toolbarView to the #_balloon and attach the #_balloon to the selection for the forward selection', () => {
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
 			const defaultPositions = BalloonPanelView.defaultPositions;
 
-			return contextualToolbar._showPanel().then( () => {
-				sinon.assert.calledWithExactly( balloonAddSpy, {
-					view: contextualToolbar.toolbarView,
-					balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container',
-					position: {
-						target: sinon.match( value => value() == backwardSelectionRect ),
-						limiter: editor.ui.view.editable.element,
-						positions: [
-							defaultPositions.southEastArrowNorth,
-							defaultPositions.southEastArrowNorthEast,
-							defaultPositions.southEastArrowNorthWest,
-							defaultPositions.northEastArrowSouth,
-							defaultPositions.northEastArrowSouthEast,
-							defaultPositions.northEastArrowSouthWest
-						]
-					}
-				} );
+			contextualToolbar._showPanel();
+
+			sinon.assert.calledWithExactly( balloonAddSpy, {
+				view: contextualToolbar.toolbarView,
+				balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container',
+				position: {
+					target: sinon.match( value => value() == backwardSelectionRect ),
+					limiter: editor.ui.view.editable.element,
+					positions: [
+						defaultPositions.southEastArrowNorth,
+						defaultPositions.southEastArrowNorthEast,
+						defaultPositions.southEastArrowNorthWest,
+						defaultPositions.northEastArrowSouth,
+						defaultPositions.northEastArrowSouthEast,
+						defaultPositions.northEastArrowSouthWest
+					]
+				}
 			} );
 		} );
 
@@ -181,25 +171,24 @@ describe( 'ContextualToolbar', () => {
 
 			const defaultPositions = BalloonPanelView.defaultPositions;
 
-			return contextualToolbar._showPanel()
-				.then( () => {
-					sinon.assert.calledWithExactly( balloonAddSpy, {
-						view: contextualToolbar.toolbarView,
-						balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container',
-						position: {
-							target: sinon.match( value => value() == forwardSelectionRect ),
-							limiter: editor.ui.view.editable.element,
-							positions: [
-								defaultPositions.northWestArrowSouth,
-								defaultPositions.northWestArrowSouthWest,
-								defaultPositions.northWestArrowSouthEast,
-								defaultPositions.southWestArrowNorth,
-								defaultPositions.southWestArrowNorthWest,
-								defaultPositions.southWestArrowNorthEast
-							]
-						}
-					} );
-				} );
+			contextualToolbar._showPanel();
+
+			sinon.assert.calledWithExactly( balloonAddSpy, {
+				view: contextualToolbar.toolbarView,
+				balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container',
+				position: {
+					target: sinon.match( value => value() == forwardSelectionRect ),
+					limiter: editor.ui.view.editable.element,
+					positions: [
+						defaultPositions.northWestArrowSouth,
+						defaultPositions.northWestArrowSouthWest,
+						defaultPositions.northWestArrowSouthEast,
+						defaultPositions.southWestArrowNorth,
+						defaultPositions.southWestArrowNorthWest,
+						defaultPositions.southWestArrowNorthEast
+					]
+				}
+			} );
 		} );
 
 		it( 'should update balloon position on ViewDocument#render event while balloon is added to the #_balloon', () => {
@@ -209,43 +198,34 @@ describe( 'ContextualToolbar', () => {
 
 			editor.editing.view.fire( 'render' );
 
-			return contextualToolbar._showPanel()
-				.then( () => {
-					sinon.assert.notCalled( spy );
+			contextualToolbar._showPanel();
+			sinon.assert.notCalled( spy );
 
-					editor.editing.view.fire( 'render' );
-
-					sinon.assert.calledOnce( spy );
-				} );
+			editor.editing.view.fire( 'render' );
+			sinon.assert.calledOnce( spy );
 		} );
 
 		it( 'should not add #toolbarView to the #_balloon more than once', () => {
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
-			return contextualToolbar._showPanel()
-				.then( () => contextualToolbar._showPanel() )
-				.then( () => {
-					sinon.assert.calledOnce( balloonAddSpy );
-				} );
+			contextualToolbar._showPanel();
+			contextualToolbar._showPanel();
+			sinon.assert.calledOnce( balloonAddSpy );
 		} );
 
 		it( 'should not add #toolbarView to the #_balloon when editor is not focused', () => {
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 			editor.editing.view.isFocused = false;
 
-			return contextualToolbar._showPanel()
-				.then( () => {
-					sinon.assert.notCalled( balloonAddSpy );
-				} );
+			contextualToolbar._showPanel();
+			sinon.assert.notCalled( balloonAddSpy );
 		} );
 
 		it( 'should not add #toolbarView to the #_balloon when selection is collapsed', () => {
 			setData( editor.document, '<paragraph>b[]ar</paragraph>' );
 
-			return contextualToolbar._showPanel()
-				.then( () => {
-					sinon.assert.notCalled( balloonAddSpy );
-				} );
+			contextualToolbar._showPanel();
+			sinon.assert.notCalled( balloonAddSpy );
 		} );
 	} );
 
@@ -260,12 +240,10 @@ describe( 'ContextualToolbar', () => {
 		it( 'should remove #toolbarView from the #_balloon', () => {
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
-			return contextualToolbar._showPanel()
-				.then( () => {
-					contextualToolbar._hidePanel();
+			contextualToolbar._showPanel();
 
-					sinon.assert.calledWithExactly( removeBalloonSpy, contextualToolbar.toolbarView );
-				} );
+			contextualToolbar._hidePanel();
+			sinon.assert.calledWithExactly( removeBalloonSpy, contextualToolbar.toolbarView );
 		} );
 
 		it( 'should stop update balloon position on ViewDocument#render event', () => {
@@ -273,14 +251,11 @@ describe( 'ContextualToolbar', () => {
 
 			const spy = sandbox.spy( balloon, 'updatePosition' );
 
-			return contextualToolbar._showPanel()
-				.then( () => {
-					contextualToolbar._hidePanel();
+			contextualToolbar._showPanel();
+			contextualToolbar._hidePanel();
 
-					editor.editing.view.fire( 'render' );
-
-					sinon.assert.notCalled( spy );
-				} );
+			editor.editing.view.fire( 'render' );
+			sinon.assert.notCalled( spy );
 		} );
 
 		it( 'should not remove #ttolbarView when is not added to the #_balloon', () => {
@@ -320,7 +295,6 @@ describe( 'ContextualToolbar', () => {
 		beforeEach( () => {
 			setData( editor.document, '<paragraph>[bar]</paragraph>' );
 
-			// Methods are stubbed because return internal promise which can't be returned in test.
 			showPanelSpy = sandbox.stub( contextualToolbar, '_showPanel', () => {} );
 			hidePanelSpy = sandbox.stub( contextualToolbar, '_hidePanel', () => {} );
 		} );
@@ -421,11 +395,8 @@ describe( 'ContextualToolbar', () => {
 			contextualToolbar.on( 'beforeShow', spy );
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
-			const promise = contextualToolbar._showPanel();
-
+			contextualToolbar._showPanel();
 			sinon.assert.calledOnce( spy );
-
-			return promise;
 		} );
 
 		it( 'should not show the panel when `beforeShow` event is stopped', () => {
@@ -437,9 +408,8 @@ describe( 'ContextualToolbar', () => {
 				stop();
 			} );
 
-			return contextualToolbar._showPanel().then( () => {
-				sinon.assert.notCalled( balloonAddSpy );
-			} );
+			contextualToolbar._showPanel();
+			sinon.assert.notCalled( balloonAddSpy );
 		} );
 	} );
 

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -295,8 +295,8 @@ describe( 'ContextualToolbar', () => {
 		beforeEach( () => {
 			setData( editor.document, '<paragraph>[bar]</paragraph>' );
 
-			showPanelSpy = sandbox.stub( contextualToolbar, '_showPanel', () => {} );
-			hidePanelSpy = sandbox.stub( contextualToolbar, '_hidePanel', () => {} );
+			showPanelSpy = sandbox.spy( contextualToolbar, '_showPanel' );
+			hidePanelSpy = sandbox.spy( contextualToolbar, '_hidePanel' );
 		} );
 
 		it( 'should open when selection stops changing', () => {

--- a/tests/toolbar/sticky/stickytoolbarview.js
+++ b/tests/toolbar/sticky/stickytoolbarview.js
@@ -174,32 +174,23 @@ describe( 'StickyToolbarView', () => {
 	} );
 
 	describe( 'destroy()', () => {
-		it( 'should return a promise', () => {
-			expect( view.destroy() ).to.be.instanceof( Promise );
-		} );
-
-		it( 'can be called multiple times', done => {
+		it( 'can be called multiple times', () => {
 			expect( () => {
-				view.destroy().then( () => {
-					return view.destroy().then( () => {
-						done();
-					} );
-				} );
+				view.destroy();
+				view.destroy();
 			} ).to.not.throw();
 		} );
 
 		it( 'calls destroy on parent class', () => {
 			const spy = testUtils.sinon.spy( ToolbarView.prototype, 'destroy' );
 
-			return view.destroy().then( () => {
-				expect( spy.calledOnce ).to.be.true;
-			} );
+			view.destroy();
+			expect( spy.calledOnce ).to.be.true;
 		} );
 
 		it( 'removes view._elementPlaceholder from DOM', () => {
-			return view.destroy().then( () => {
-				expect( view._elementPlaceholder.parentNode ).to.be.null;
-			} );
+			view.destroy();
+			expect( view._elementPlaceholder.parentNode ).to.be.null;
 		} );
 	} );
 

--- a/tests/toolbar/toolbarview.js
+++ b/tests/toolbar/toolbarview.js
@@ -21,8 +21,7 @@ describe( 'ToolbarView', () => {
 	beforeEach( () => {
 		locale = {};
 		view = new ToolbarView( locale );
-
-		return view.init();
+		view.init();
 	} );
 
 	describe( 'constructor()', () => {
@@ -82,10 +81,9 @@ describe( 'ToolbarView', () => {
 
 			const spy = sinon.spy( view.keystrokes, 'listenTo' );
 
-			return view.init().then( () => {
-				sinon.assert.calledOnce( spy );
-				sinon.assert.calledWithExactly( spy, view.element );
-			} );
+			view.init();
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, view.element );
 		} );
 
 		describe( 'activates keyboard navigation for the toolbar', () => {
@@ -232,21 +230,22 @@ describe( 'ToolbarView', () => {
 			factory.add( 'bar', namedFactory( 'bar' ) );
 		} );
 
-		it( 'returns a promise', () => {
-			expect( view.fillFromConfig() ).to.be.instanceOf( Promise );
+		it( 'does not throw when no config is provided', () => {
+			expect( () => {
+				view.fillFromConfig();
+			} ).to.not.throw();
 		} );
 
 		it( 'expands the config into collection', () => {
-			return view.fillFromConfig( [ 'foo', 'bar', '|', 'foo' ], factory )
-				.then( () => {
-					const items = view.items;
+			view.fillFromConfig( [ 'foo', 'bar', '|', 'foo' ], factory );
 
-					expect( items ).to.have.length( 4 );
-					expect( items.get( 0 ).name ).to.equal( 'foo' );
-					expect( items.get( 1 ).name ).to.equal( 'bar' );
-					expect( items.get( 2 ) ).to.be.instanceOf( ToolbarSeparatorView );
-					expect( items.get( 3 ).name ).to.equal( 'foo' );
-				} );
+			const items = view.items;
+
+			expect( items ).to.have.length( 4 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ).name ).to.equal( 'bar' );
+			expect( items.get( 2 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 3 ).name ).to.equal( 'foo' );
 		} );
 	} );
 } );

--- a/tests/view.js
+++ b/tests/view.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* global document, setTimeout, HTMLElement */
+/* global document, HTMLElement */
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import View from '../src/view';
@@ -87,47 +87,21 @@ describe( 'View', () => {
 			setTestViewInstance();
 		} );
 
-		it( 'should return a promise', () => {
-			const spy = sinon.spy();
-			const child = {
-				init: () => {
-					return new Promise( resolve => {
-						setTimeout( () => resolve(), 100 );
-					} )
-					.then( () => spy() );
-				}
-			};
-
-			return view.init()
-				.then( () => {
-					const returned = view.addChildren( child );
-					expect( returned ).to.be.instanceof( Promise );
-
-					return returned.then( () => {
-						sinon.assert.calledOnce( spy );
-					} );
-				} );
-		} );
-
 		it( 'should add a single view to #_unboundChildren', () => {
 			expect( view._unboundChildren ).to.have.length( 0 );
 
 			const child = {};
 
-			return view.addChildren( child )
-				.then( () => {
-					expect( view._unboundChildren ).to.have.length( 1 );
-					expect( view._unboundChildren.get( 0 ) ).to.equal( child );
-				} );
+			view.addChildren( child );
+			expect( view._unboundChildren ).to.have.length( 1 );
+			expect( view._unboundChildren.get( 0 ) ).to.equal( child );
 		} );
 
 		it( 'should support iterables', () => {
 			expect( view._unboundChildren ).to.have.length( 0 );
 
-			return view.addChildren( [ {}, {}, {} ] )
-				.then( () => {
-					expect( view._unboundChildren ).to.have.length( 3 );
-				} );
+			view.addChildren( [ {}, {}, {} ] );
+			expect( view._unboundChildren ).to.have.length( 3 );
 		} );
 	} );
 
@@ -135,28 +109,22 @@ describe( 'View', () => {
 		beforeEach( createViewWithChildren );
 
 		it( 'should throw if already initialized', () => {
-			return view.init()
-				.then( () => {
-					view.init();
+			view.init();
 
-					throw new Error( 'This should not be executed.' );
-				} )
-				.catch( err => {
-					expect( err ).to.be.instanceof( CKEditorError );
-					expect( err.message ).to.match( /ui-view-init-re/ );
-				} );
-		} );
-
-		it( 'returns a promise', () => {
-			expect( view.init() ).to.be.instanceof( Promise );
+			try {
+				view.init();
+				throw new Error( 'This should not be executed.' );
+			} catch ( err ) {
+				expect( err ).to.be.instanceof( CKEditorError );
+				expect( err.message ).to.match( /ui-view-init-re/ );
+			}
 		} );
 
 		it( 'should set view#ready', () => {
 			expect( view.ready ).to.be.false;
 
-			return view.init().then( () => {
-				expect( view.ready ).to.be.true;
-			} );
+			view.init();
+			expect( view.ready ).to.be.true;
 		} );
 
 		it( 'calls init() on all view#_viewCollections', () => {
@@ -166,11 +134,10 @@ describe( 'View', () => {
 			const spyA = testUtils.sinon.spy( collectionA, 'init' );
 			const spyB = testUtils.sinon.spy( collectionB, 'init' );
 
-			return view.init().then( () => {
-				sinon.assert.calledOnce( spyA );
-				sinon.assert.calledOnce( spyB );
-				sinon.assert.callOrder( spyA, spyB );
-			} );
+			view.init();
+			sinon.assert.calledOnce( spyA );
+			sinon.assert.calledOnce( spyB );
+			sinon.assert.callOrder( spyA, spyB );
 		} );
 	} );
 
@@ -261,47 +228,32 @@ describe( 'View', () => {
 	describe( 'destroy()', () => {
 		beforeEach( createViewWithChildren );
 
-		it( 'should return a promise', () => {
-			const promise = view.destroy();
-
-			expect( promise ).to.be.instanceof( Promise );
-
-			return promise;
-		} );
-
-		it( 'can be called multiple times', done => {
+		it( 'can be called multiple times', () => {
 			expect( () => {
-				view.destroy().then( () => {
-					return view.destroy().then( () => {
-						done();
-					} );
-				} );
+				view.destroy();
 			} ).to.not.throw();
 		} );
 
 		it( 'should not touch the basic properties', () => {
-			return view.destroy().then( () => {
-				expect( view.element ).to.be.an.instanceof( HTMLElement );
-				expect( view.template ).to.be.an.instanceof( Template );
-				expect( view.locale ).to.be.an( 'object' );
-				expect( view.locale.t ).to.be.a( 'function' );
+			view.destroy();
 
-				expect( view._viewCollections ).to.be.instanceOf( Collection );
-				expect( view._unboundChildren ).to.be.instanceOf( ViewCollection );
-			} );
+			expect( view.element ).to.be.an.instanceof( HTMLElement );
+			expect( view.template ).to.be.an.instanceof( Template );
+			expect( view.locale ).to.be.an( 'object' );
+			expect( view.locale.t ).to.be.a( 'function' );
+
+			expect( view._viewCollections ).to.be.instanceOf( Collection );
+			expect( view._unboundChildren ).to.be.instanceOf( ViewCollection );
 		} );
 
 		it( 'should not clear the #_unboundChildren', () => {
 			const cached = view._unboundChildren;
 
-			return view.addChildren( [ new View(), new View() ] )
-				.then( () => {
-					expect( cached ).to.have.length( 4 );
+			view.addChildren( [ new View(), new View() ] );
+			expect( cached ).to.have.length( 4 );
 
-					return view.destroy().then( () => {
-						expect( cached ).to.have.length( 4 );
-					} );
-				} );
+			view.destroy();
+			expect( cached ).to.have.length( 4 );
 		} );
 
 		it( 'should not clear the #_viewCollections', () => {
@@ -309,9 +261,8 @@ describe( 'View', () => {
 
 			expect( cached ).to.have.length( 1 );
 
-			return view.destroy().then( () => {
-				expect( cached ).to.have.length( 1 );
-			} );
+			view.destroy();
+			expect( cached ).to.have.length( 1 );
 		} );
 
 		it( 'leaves the #element in DOM', () => {
@@ -320,9 +271,8 @@ describe( 'View', () => {
 
 			parentEl.appendChild( view.element );
 
-			return view.destroy().then( () => {
-				expect( elRef.parentNode ).to.equal( parentEl );
-			} );
+			view.destroy();
+			expect( elRef.parentNode ).to.equal( parentEl );
 		} );
 
 		it( 'calls destroy() on all view#_viewCollections', () => {
@@ -332,61 +282,18 @@ describe( 'View', () => {
 			const spyA = testUtils.sinon.spy( collectionA, 'destroy' );
 			const spyB = testUtils.sinon.spy( collectionB, 'destroy' );
 
-			return view.destroy().then( () => {
-				sinon.assert.calledOnce( spyA );
-				sinon.assert.calledOnce( spyB );
-				sinon.assert.callOrder( spyA, spyB );
-			} );
+			view.destroy();
+			sinon.assert.calledOnce( spyA );
+			sinon.assert.calledOnce( spyB );
+			sinon.assert.callOrder( spyA, spyB );
 		} );
 
 		it( 'destroy a template–less view', () => {
-			let promise;
-
 			view = new View();
 
 			expect( () => {
-				promise = view.destroy();
+				view.destroy();
 			} ).to.not.throw();
-
-			return promise;
-		} );
-
-		// https://github.com/ckeditor/ckeditor5-ui/issues/203
-		it( 'waits for all #addChildren promises to resolve', () => {
-			const spyA = sinon.spy();
-			const spyB = sinon.spy();
-
-			class DelayedInitView extends View {
-				constructor( delay, spy ) {
-					super();
-
-					this.delay = delay;
-					this.spy = spy;
-				}
-
-				init() {
-					return new Promise( resolve => {
-						setTimeout( () => resolve(), this.delay );
-					} )
-						.then( () => super.init() )
-						.then( () => {
-							this.spy();
-						} );
-				}
-			}
-
-			const viewA = new DelayedInitView( 200, spyA );
-			const viewB = new DelayedInitView( 100, spyB );
-
-			return view.init().then( () => {
-				view.addChildren( [ viewA, viewB ] );
-
-				return view.destroy().then( () => {
-					expect( viewA.ready ).to.be.true;
-					expect( viewB.ready ).to.be.true;
-					sinon.assert.callOrder( spyB, spyA );
-				} );
-			} );
 		} );
 	} );
 } );
@@ -429,44 +336,8 @@ function createViewWithChildren() {
 		}
 	}
 
-	class ChildViewA extends ChildView {
-		init() {
-			const promise = new Promise( resolve => {
-				setTimeout( resolve, 50 );
-			} );
-
-			return super.init().then( promise );
-		}
-
-		destroy() {
-			const promise = new Promise( resolve => {
-				setTimeout( resolve, 10 );
-			} );
-
-			return super.destroy().then( promise );
-		}
-	}
-
-	class ChildViewB extends ChildView {
-		init() {
-			const promise = new Promise( resolve => {
-				setTimeout( resolve, 10 );
-			} );
-
-			return super.init().then( promise );
-		}
-
-		destroy() {
-			const promise = new Promise( resolve => {
-				setTimeout( resolve, 50 );
-			} );
-
-			return super.destroy().then( promise );
-		}
-	}
-
-	childA = new ChildViewA();
-	childB = new ChildViewB();
+	childA = new ChildView();
+	childB = new ChildView();
 
 	setTestViewClass( {
 		tag: 'p',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Made the UI component initialization and destruction processes synchronous. Closes #225.

BREAKING CHANGE: `View#init`, `View#destroy` (also `ViewCollection#init`, `ViewCollection#destroy` and `ViewCollection#add`) no longer return `Promise`. It may require updates in UI components which inherit from `View` and rely on the value returned by these methods.

BREAKING CHANGE: Various UI components switched to synchronous `init()` and `destroy()` (no longer returning `Promise`), which means that features using these components may need some updates to work properly.

---

### Additional information

CI branch is https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-ui/225, also pointing to related branches in other repositories aligning the API to the changes in this issue. They can't be merged one by one so it's all or nothing merge. CI in https://travis-ci.org/ckeditor/ckeditor5/builds/249943542.

Commit message for related branches:

```
Internal: Updated the usage of UI components which are now driven by synchronous initialization and destruction (see ckeditor/ckeditor5-ui#225).
```

@oskarwrobel: Can you take a look on `ContextualBalloon` and `ContextualToolbar` classes? I made them synchronous but AFAIR because of the asynchronous API the tests were full of hacks. Perhaps you may have some ideas as to how to simplify them even more?