### PR TITLE
Added TextInputView#isReadOnly state.

### DIFF
--- a/src/inputtext/inputtextview.js
+++ b/src/inputtext/inputtextview.js
@@ -46,6 +46,14 @@ export default class InputTextView extends View {
 		 */
 		this.set( 'placeholder' );
 
+		/**
+		 * Controls whether the input view is in read-only mode.
+		 *
+		 * @observable
+		 * @member {Boolean} #isReadOnly
+		 */
+		this.set( 'isReadOnly', false );
+
 		const bind = this.bindTemplate;
 
 		this.template = new Template( {
@@ -57,7 +65,8 @@ export default class InputTextView extends View {
 					'ck-input-text'
 				],
 				id: bind.to( 'id' ),
-				placeholder: bind.to( 'placeholder' )
+				placeholder: bind.to( 'placeholder' ),
+				readonly: bind.to( 'isReadOnly' )
 			}
 		} );
 

--- a/src/labeledinput/labeledinputview.js
+++ b/src/labeledinput/labeledinputview.js
@@ -68,9 +68,15 @@ export default class LabeledInputView extends View {
 		 */
 		this.inputView = this._createInputView( InputView, id );
 
+		const bind = this.bindTemplate;
+
 		this.template = new Template( {
 			tag: 'div',
-
+			attributes: {
+				class: [
+					bind.if( 'isReadOnly', 'ck-disabled' )
+				]
+			},
 			children: [
 				this.labelView,
 				this.inputView

--- a/src/labeledinput/labeledinputview.js
+++ b/src/labeledinput/labeledinputview.js
@@ -47,6 +47,14 @@ export default class LabeledInputView extends View {
 		this.set( 'value' );
 
 		/**
+		 * Controls whether the component is in read-only mode.
+		 *
+		 * @observable
+		 * @member {Boolean} #isReadOnly
+		 */
+		this.set( 'isReadOnly', false );
+
+		/**
 		 * The label view.
 		 *
 		 * @member {module:ui/label/labelview~LabelView} #labelView
@@ -99,6 +107,7 @@ export default class LabeledInputView extends View {
 
 		inputView.id = id;
 		inputView.bind( 'value' ).to( this );
+		inputView.bind( 'isReadOnly' ).to( this );
 
 		return inputView;
 	}

--- a/tests/inputtext/inputtextview.js
+++ b/tests/inputtext/inputtextview.js
@@ -66,6 +66,16 @@ describe( 'InputTextView', () => {
 				expect( view.element.placeholder ).to.equal( 'baz' );
 			} );
 		} );
+
+		describe( 'isReadOnly', () => {
+			it( 'should react on view#isReadOnly', () => {
+				expect( view.element.readOnly ).to.false;
+
+				view.isReadOnly = true;
+
+				expect( view.element.readOnly ).to.true;
+			} );
+		} );
 	} );
 
 	describe( 'select()', () => {

--- a/tests/labeledinput/labeledinputview.js
+++ b/tests/labeledinput/labeledinputview.js
@@ -58,6 +58,16 @@ describe( 'LabeledInputView', () => {
 
 			expect( view.inputView.value ).to.equal( 'Lorem ipsum' );
 		} );
+
+		it( 'should bind view#isreadOnly to view.inputView#isReadOnly', () => {
+			view.isReadOnly = false;
+
+			expect( view.inputView.isReadOnly ).to.false;
+
+			view.isReadOnly = true;
+
+			expect( view.inputView.isReadOnly ).to.true;
+		} );
 	} );
 
 	describe( 'select()', () => {

--- a/tests/labeledinput/labeledinputview.js
+++ b/tests/labeledinput/labeledinputview.js
@@ -44,6 +44,18 @@ describe( 'LabeledInputView', () => {
 		it( 'should have input view', () => {
 			expect( view.template.children.get( 1 ) ).to.equal( view.inputView );
 		} );
+
+		describe( 'DOM bindings', () => {
+			describe( 'class', () => {
+				it( 'should react on view#isReadOnly', () => {
+					view.isReadOnly = false;
+					expect( view.element.classList.contains( 'ck-disabled' ) ).to.be.false;
+
+					view.isReadOnly = true;
+					expect( view.element.classList.contains( 'ck-disabled' ) ).to.be.true;
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'binding', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added `TextInputView#isReadOnly` and `LabeledInputView#isReadOnly`  states. Closes #266. Closes #268.