### PR TITLE
t/263: Implemented public show and hide methods in the ContextualToolbar plugin

### DIFF
--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -157,11 +157,6 @@ export default class ContextualToolbar extends Plugin {
 			return;
 		}
 
-		// This implementation assumes that only non–collapsed selections gets the contextual toolbar.
-		if ( !editingView.isFocused || editingView.selection.isCollapsed ) {
-			return;
-		}
-
 		// If `beforeShow` event is not stopped by any external code then panel will be displayed.
 		this.once( 'beforeShow', () => {
 			if ( isStopped ) {

--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -13,6 +13,7 @@ import ContextualBalloon from '../../panel/balloon/contextualballoon';
 import ToolbarView from '../toolbarview';
 import BalloonPanelView from '../../panel/balloon/balloonpanelview.js';
 import debounce from '@ckeditor/ckeditor5-utils/src/lib/lodash/debounce';
+import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
 
 /**
  * The contextual toolbar.
@@ -104,7 +105,7 @@ export default class ContextualToolbar extends Plugin {
 		// Hide the panel View when editor loses focus but no the other way around.
 		this.listenTo( editor.ui.focusTracker, 'change:isFocused', ( evt, name, isFocused ) => {
 			if ( this._balloon.visibleView === this.toolbarView && !isFocused ) {
-				this._hidePanel();
+				this.hide();
 			}
 		} );
 	}
@@ -120,12 +121,13 @@ export default class ContextualToolbar extends Plugin {
 	 */
 	_handleSelectionChange() {
 		const selection = this.editor.document.selection;
+		const editingView = this.editor.editing.view;
 
 		this.listenTo( selection, 'change:range', ( evt, data ) => {
 			// When the selection is not changed by a collaboration and when is not collapsed.
 			if ( data.directChange || selection.isCollapsed ) {
 				// Hide the toolbar when the selection starts changing.
-				this._hidePanel();
+				this.hide();
 			}
 
 			// Fire internal `_selectionChangeDebounced` when the selection stops changing.
@@ -133,17 +135,20 @@ export default class ContextualToolbar extends Plugin {
 		} );
 
 		// Hide the toolbar when the selection stops changing.
-		this.listenTo( this, '_selectionChangeDebounced', () => this._showPanel() );
+		this.listenTo( this, '_selectionChangeDebounced', () => {
+			// This implementation assumes that only non–collapsed selections gets the contextual toolbar.
+			if ( editingView.isFocused && !editingView.selection.isCollapsed ) {
+				this.show();
+			}
+		} );
 	}
 
 	/**
 	 * Adds panel view to the {@link: #_balloon} and attaches panel to the selection.
 	 *
 	 * Fires {@link #event:beforeShow} event just before displaying the panel.
-	 *
-	 * @protected
 	 */
-	_showPanel() {
+	show() {
 		const editingView = this.editor.editing.view;
 		let isStopped = false;
 
@@ -185,11 +190,9 @@ export default class ContextualToolbar extends Plugin {
 	}
 
 	/**
-	 * Removes panel from the {@link: #_balloon}.
-	 *
-	 * @private
+	 * Removes the toolbar from the {@link: #_balloon} which hides it.
 	 */
-	_hidePanel() {
+	hide() {
 		if ( this._balloon.hasView( this.toolbarView ) ) {
 			this.stopListening( this.editor.editing.view, 'render' );
 			this._balloon.remove( this.toolbarView );
@@ -215,13 +218,11 @@ export default class ContextualToolbar extends Plugin {
 			// computed and hence, the target is defined as a function instead of a static value.
 			// https://github.com/ckeditor/ckeditor5-ui/issues/195
 			target: () => {
-				// getBoundingClientRect() makes no sense when the selection spans across number
-				// of lines of text. Using getClientRects() allows us to browse micro–ranges
-				// that would normally make up the bounding client rect.
-				const rangeRects = editingView.domConverter.viewRangeToDom( editingView.selection.getFirstRange() ).getClientRects();
+				const range = editingView.selection.getFirstRange();
+				const rangeRects = Rect.getDomRangeRects( editingView.domConverter.viewRangeToDom( range ) );
 
 				// Select the proper range rect depending on the direction of the selection.
-				return isBackward ? rangeRects.item( 0 ) : rangeRects.item( rangeRects.length - 1 );
+				return rangeRects[ isBackward ? 0 : rangeRects.length - 1 ];
 			},
 			limiter: this.editor.ui.view.editable.element,
 			positions: getBalloonPositions( isBackward )

--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -144,7 +144,7 @@ export default class ContextualToolbar extends Plugin {
 	}
 
 	/**
-	 * Adds panel view to the {@link: #_balloon} and attaches panel to the selection.
+	 * Shows the toolbar and attaches it to the selection.
 	 *
 	 * Fires {@link #event:beforeShow} event just before displaying the panel.
 	 */
@@ -185,7 +185,7 @@ export default class ContextualToolbar extends Plugin {
 	}
 
 	/**
-	 * Removes the toolbar from the {@link: #_balloon} which hides it.
+	 * Hides the toolbar.
 	 */
 	hide() {
 		if ( this._balloon.hasView( this.toolbarView ) ) {

--- a/src/toolbar/enabletoolbarkeyboardfocus.js
+++ b/src/toolbar/enabletoolbarkeyboardfocus.js
@@ -19,6 +19,10 @@
  * for `options.origin`.
  * @param {module:ui/toolbar/toolbarview~ToolbarView} options.toolbar A toolbar which is to gain
  * focus when `Alt+F10` is pressed.
+ * @param {Function} [options.beforeFocus] A callback executed before the `options.toolbar` gains focus
+ * upon the `Alt+F10` keystroke.
+ * @param {Function} [options.afterBlur] A callback executed after `options.toolbar` loses focus upon
+ * `Esc` keystroke but before the focus goes back to `options.origin`.
  */
 export default function enableToolbarKeyboardFocus( {
 	origin,

--- a/src/toolbar/enabletoolbarkeyboardfocus.js
+++ b/src/toolbar/enabletoolbarkeyboardfocus.js
@@ -24,7 +24,9 @@ export default function enableToolbarKeyboardFocus( {
 	origin,
 	originKeystrokeHandler,
 	originFocusTracker,
-	toolbar
+	toolbar,
+	beforeFocus,
+	afterBlur
 } ) {
 	// Because toolbar items can get focus, the overall state of the toolbar must
 	// also be tracked.
@@ -33,7 +35,12 @@ export default function enableToolbarKeyboardFocus( {
 	// Focus the toolbar on the keystroke, if not already focused.
 	originKeystrokeHandler.set( 'Alt+F10', ( data, cancel ) => {
 		if ( originFocusTracker.isFocused && !toolbar.focusTracker.isFocused ) {
+			if ( beforeFocus ) {
+				beforeFocus();
+			}
+
 			toolbar.focus();
+
 			cancel();
 		}
 	} );
@@ -42,6 +49,11 @@ export default function enableToolbarKeyboardFocus( {
 	toolbar.keystrokes.set( 'Esc', ( data, cancel ) => {
 		if ( toolbar.focusTracker.isFocused ) {
 			origin.focus();
+
+			if ( afterBlur ) {
+				afterBlur();
+			}
+
 			cancel();
 		}
 	} );

--- a/tests/toolbar/enabletoolbarkeyboardfocus.js
+++ b/tests/toolbar/enabletoolbarkeyboardfocus.js
@@ -28,7 +28,7 @@ describe( 'enableToolbarKeyboardFocus()', () => {
 			toolbar
 		} );
 
-		return toolbar.init();
+		toolbar.init();
 	} );
 
 	it( 'focuses the toolbar on Alt+F10', () => {
@@ -66,7 +66,8 @@ describe( 'enableToolbarKeyboardFocus()', () => {
 	it( 're–foucuses origin on Esc', () => {
 		const spy = origin.focus = sinon.spy();
 		const toolbarFocusTracker = toolbar.focusTracker;
-		const keyEvtData = { keyCode: keyCodes.esc,
+		const keyEvtData = {
+			keyCode: keyCodes.esc,
 			preventDefault: sinon.spy(),
 			stopPropagation: sinon.spy()
 		};
@@ -83,6 +84,55 @@ describe( 'enableToolbarKeyboardFocus()', () => {
 		sinon.assert.calledOnce( spy );
 		sinon.assert.calledOnce( keyEvtData.preventDefault );
 		sinon.assert.calledOnce( keyEvtData.stopPropagation );
+	} );
+
+	it( 'supports beforeFocus and afterBlur callbacks', () => {
+		const beforeFocus = sinon.spy();
+		const afterBlur = sinon.spy();
+
+		origin = viewCreator();
+		originFocusTracker = new FocusTracker();
+		originKeystrokeHandler = new KeystrokeHandler();
+		toolbar = new ToolbarView();
+
+		const toolbarFocusSpy = sinon.spy( toolbar, 'focus' );
+		const originFocusSpy = origin.focus = sinon.spy();
+		const toolbarFocusTracker = toolbar.focusTracker;
+
+		enableToolbarKeyboardFocus( {
+			origin,
+			originFocusTracker,
+			originKeystrokeHandler,
+			toolbar,
+			beforeFocus,
+			afterBlur
+		} );
+
+		toolbar.init();
+
+		let keyEvtData = {
+			keyCode: keyCodes.f10,
+			altKey: true,
+			preventDefault: sinon.spy(),
+			stopPropagation: sinon.spy()
+		};
+
+		toolbarFocusTracker.isFocused = false;
+		originFocusTracker.isFocused = true;
+
+		originKeystrokeHandler.press( keyEvtData );
+		sinon.assert.callOrder( beforeFocus, toolbarFocusSpy );
+
+		keyEvtData = {
+			keyCode: keyCodes.esc,
+			preventDefault: sinon.spy(),
+			stopPropagation: sinon.spy()
+		};
+
+		toolbarFocusTracker.isFocused = true;
+
+		toolbar.keystrokes.press( keyEvtData );
+		sinon.assert.callOrder( originFocusSpy, afterBlur );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Implemented public show and hide methods in the ContextualToolbar plugin. Closes #263.