### PR TITLE
ContextualToolbar is not displayed when all components inside are disabled.

### DIFF
--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -179,7 +179,7 @@ export default class ContextualToolbar extends Plugin {
 	_show() {
 		// Don not show ContextualToolbar when all components inside are disabled
 		// see https://github.com/ckeditor/ckeditor5-ui/issues/269.
-		if ( Array.from( this.toolbarView.items ).every( item => !item.isEnabled ) ) {
+		if ( Array.from( this.toolbarView.items ).every( item => item.isEnabled !== undefined && !item.isEnabled ) ) {
 			return;
 		}
 

--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -177,6 +177,12 @@ export default class ContextualToolbar extends Plugin {
 	 * @private
 	 */
 	_show() {
+		// Don not show ContextualToolbar when all components inside are disabled
+		// see https://github.com/ckeditor/ckeditor5-ui/issues/269.
+		if ( Array.from( this.toolbarView.items ).every( item => !item.isEnabled ) ) {
+			return;
+		}
+
 		// Update panel position when selection changes (by external document changes) while balloon is opened.
 		this.listenTo( this.editor.editing.view, 'render', () => {
 			this._balloon.updatePosition( this._getBalloonPositionData() );

--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -81,8 +81,8 @@ export default class ContextualToolbar extends Plugin {
 		this._handleFocusChange();
 
 		// The appearance of the ContextualToolbar method is event–driven.
-		// It is possible to stop the #show event and thus prevent the toolbar from showing up.
-		this.on( 'show', () => this._show(), { priority: 'low' } );
+		// It is possible to stop the #show event and this prevent the toolbar from showing up.
+		this.decorate( 'show' );
 	}
 
 	/**
@@ -158,25 +158,6 @@ export default class ContextualToolbar extends Plugin {
 			return;
 		}
 
-		this.fire( 'show' );
-	}
-
-	/**
-	 * Hides the toolbar.
-	 */
-	hide() {
-		if ( this._balloon.hasView( this.toolbarView ) ) {
-			this.stopListening( this.editor.editing.view, 'render' );
-			this._balloon.remove( this.toolbarView );
-		}
-	}
-
-	/**
-	 * Shows of the toolbar if the {@link #event:show} has not been stopped.
-	 *
-	 * @private
-	 */
-	_show() {
 		// Don not show the toolbar when all components inside are disabled
 		// see https://github.com/ckeditor/ckeditor5-ui/issues/269.
 		if ( Array.from( this.toolbarView.items ).every( item => item.isEnabled !== undefined && !item.isEnabled ) ) {
@@ -195,6 +176,16 @@ export default class ContextualToolbar extends Plugin {
 			position: this._getBalloonPositionData(),
 			balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container'
 		} );
+	}
+
+	/**
+	 * Hides the toolbar.
+	 */
+	hide() {
+		if ( this._balloon.hasView( this.toolbarView ) ) {
+			this.stopListening( this.editor.editing.view, 'render' );
+			this._balloon.remove( this.toolbarView );
+		}
 	}
 
 	/**

--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -150,7 +150,7 @@ export default class ContextualToolbar extends Plugin {
 	/**
 	 * Shows the toolbar and attaches it to the selection.
 	 *
-	 * Fires {@link #event:show} event which can be stopped, which prevents toolbar from showing up.
+	 * Fires {@link #event:show} event which can be stopped to prevent the toolbar from showing up.
 	 */
 	show() {
 		// Do not add the toolbar to the balloon stack twice.

--- a/tests/manual/contextualtoolbar/contextualtoolbar.html
+++ b/tests/manual/contextualtoolbar/contextualtoolbar.html
@@ -1,5 +1,6 @@
 <div id="editor">
-	<p><i>This</i> is a <strong>first line</strong> of text.</p>
+	<p><em>ContextualToolbar</em> won't show for the first block element.</p>
+	<p><em>This</em> is a <strong>first line</strong> of text.</p>
 	<p><em>This</em> is a <strong>second line</strong> of text.</p>
 	<p><em>This</em> is the <strong>end</strong> of text.</p>
 </div>

--- a/tests/manual/contextualtoolbar/contextualtoolbar.js
+++ b/tests/manual/contextualtoolbar/contextualtoolbar.js
@@ -27,7 +27,7 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 		if ( selectionRange.containsRange( blockRange ) || selectionRange.isIntersecting( blockRange ) ) {
 			evt.stop();
 		}
-	} );
+	}, { priority: 'high' } );
 } )
 .catch( err => {
 	console.error( err.stack );

--- a/tests/manual/contextualtoolbar/contextualtoolbar.js
+++ b/tests/manual/contextualtoolbar/contextualtoolbar.js
@@ -8,6 +8,7 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ArticlePresets from '@ckeditor/ckeditor5-presets/src/article';
 import ContextualToolbar from '../../../src/toolbar/contextual/contextualtoolbar';
+import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 
 ClassicEditor.create( document.querySelector( '#editor' ), {
 	plugins: [ ArticlePresets, ContextualToolbar ],
@@ -16,6 +17,17 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 } )
 .then( editor => {
 	window.editor = editor;
+
+	const contextualToolbar = editor.plugins.get( 'ContextualToolbar' );
+
+	contextualToolbar.on( 'show', evt => {
+		const selectionRange = editor.document.selection.getFirstRange();
+		const blockRange = Range.createOn( editor.document.getRoot().getChild( 0 ) );
+
+		if ( selectionRange.containsRange( blockRange ) || selectionRange.isIntersecting( blockRange ) ) {
+			evt.stop();
+		}
+	} );
 } )
 .catch( err => {
 	console.error( err.stack );

--- a/tests/manual/contextualtoolbar/contextualtoolbar.md
+++ b/tests/manual/contextualtoolbar/contextualtoolbar.md
@@ -3,3 +3,4 @@
 1. Create a non–collapsed selection.
 2. Create another non–collapsed selection but in another direction.
 3. For each selection, a contextual toolbar should appear and the beginning/end of the selection, duplicating main editor toolbar.
+4. Toolbar should not display when selection is placed in the first block element.

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -447,7 +447,7 @@ describe( 'ContextualToolbar', () => {
 
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
-			contextualToolbar.on( 'show', evt => evt.stop() );
+			contextualToolbar.on( 'show', evt => evt.stop(), { priority: 'high' } );
 
 			contextualToolbar.show();
 			sinon.assert.notCalled( balloonAddSpy );

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -227,6 +227,19 @@ describe( 'ContextualToolbar', () => {
 			sinon.assert.notCalled( balloonAddSpy );
 		} );
 
+		it( 'should add #toolbarView to the #_balloon when at least one component inside does not have #isEnabled interface', () => {
+			Array.from( contextualToolbar.toolbarView.items ).forEach( item => {
+				item.isEnabled = false;
+			} );
+
+			delete contextualToolbar.toolbarView.items.get( 0 ).isEnabled;
+
+			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
+
+			contextualToolbar.show();
+			sinon.assert.calledOnce( balloonAddSpy );
+		} );
+
 		describe( 'on #_selectionChangeDebounced event', () => {
 			let showSpy;
 

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -408,7 +408,7 @@ describe( 'ContextualToolbar', () => {
 		} );
 	} );
 
-	describe( 'beforeShow event', () => {
+	describe( 'show event', () => {
 		it( 'should fire `show` event just before panel shows', () => {
 			const spy = sinon.spy();
 

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -409,24 +409,22 @@ describe( 'ContextualToolbar', () => {
 	} );
 
 	describe( 'beforeShow event', () => {
-		it( 'should fire `beforeShow` event just before panel shows', () => {
+		it( 'should fire `show` event just before panel shows', () => {
 			const spy = sinon.spy();
 
-			contextualToolbar.on( 'beforeShow', spy );
+			contextualToolbar.on( 'show', spy );
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
 			contextualToolbar.show();
 			sinon.assert.calledOnce( spy );
 		} );
 
-		it( 'should not show the panel when `beforeShow` event is stopped', () => {
+		it( 'should not show the panel when `show` event is stopped', () => {
 			const balloonAddSpy = sandbox.spy( balloon, 'add' );
 
 			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
 
-			contextualToolbar.on( 'beforeShow', ( evt, stop ) => {
-				stop();
-			} );
+			contextualToolbar.on( 'show', evt => evt.stop() );
 
 			contextualToolbar.show();
 			sinon.assert.notCalled( balloonAddSpy );

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -217,6 +217,16 @@ describe( 'ContextualToolbar', () => {
 			sinon.assert.calledOnce( balloonAddSpy );
 		} );
 
+		it( 'should not add #toolbarView to the #_balloon when all components inside #toolbarView are disabled', () => {
+			Array.from( contextualToolbar.toolbarView.items ).forEach( item => {
+				item.isEnabled = false;
+			} );
+			setData( editor.document, '<paragraph>b[a]r</paragraph>' );
+
+			contextualToolbar.show();
+			sinon.assert.notCalled( balloonAddSpy );
+		} );
+
 		describe( 'on #_selectionChangeDebounced event', () => {
 			let showSpy;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `ContextualToolbar#beforeShow` event is replaced by a `ContextualToolbar#show` event. `ContextualToolbar` is not displayed when all components inside are disabled. Closes #269. Closes #232.

BREAKING CHANGE: `ContextualToolbar#beforeShow` event is replaced by a `ContextualToolbar#show`.