### PR TITLE
t/281: The clickOutsideHandler helper should use mousedown instead of mouseup event

### DIFF
--- a/src/bindings/clickoutsidehandler.js
+++ b/src/bindings/clickoutsidehandler.js
@@ -22,7 +22,7 @@
  * @param {Function} options.callback Function fired after clicking outside of specified elements.
  */
 export default function clickOutsideHandler( { emitter, activator, callback, contextElements } ) {
-	emitter.listenTo( document, 'mouseup', ( evt, { target } ) => {
+	emitter.listenTo( document, 'mousedown', ( evt, { target } ) => {
 		if ( !activator() ) {
 			return;
 		}

--- a/tests/bindings/clickoutsidehandler.js
+++ b/tests/bindings/clickoutsidehandler.js
@@ -129,4 +129,14 @@ describe( 'clickOutsideHandler', () => {
 		// Called one more time.
 		sinon.assert.calledTwice( actionSpy );
 	} );
+
+	it( 'should not execute the callback if one of #contextElements contains the DOM event target', () => {
+		const target = document.createElement( 'div' );
+		activator.returns( true );
+
+		contextElement2.appendChild( target );
+		target.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
+
+		sinon.assert.notCalled( actionSpy );
+	} );
 } );

--- a/tests/bindings/clickoutsidehandler.js
+++ b/tests/bindings/clickoutsidehandler.js
@@ -41,7 +41,7 @@ describe( 'clickOutsideHandler', () => {
 	it( 'should fired callback after clicking out of context element when listener is active', () => {
 		activator.returns( true );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		sinon.assert.calledOnce( actionSpy );
 	} );
@@ -49,7 +49,7 @@ describe( 'clickOutsideHandler', () => {
 	it( 'should not fired callback after clicking out of context element when listener is not active', () => {
 		activator.returns( false );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		sinon.assert.notCalled( actionSpy );
 	} );
@@ -86,7 +86,7 @@ describe( 'clickOutsideHandler', () => {
 			callback: spy
 		} );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		sinon.assert.calledOnce( spy );
 	} );
@@ -103,7 +103,7 @@ describe( 'clickOutsideHandler', () => {
 			callback: spy
 		} );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		sinon.assert.notCalled( spy );
 	} );
@@ -111,20 +111,20 @@ describe( 'clickOutsideHandler', () => {
 	it( 'should react on model `ifActive` property change', () => {
 		activator.returns( true );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		sinon.assert.calledOnce( actionSpy );
 
 		activator.returns( false );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		// Still called once, was not called second time.
 		sinon.assert.calledOnce( actionSpy );
 
 		activator.returns( true );
 
-		document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		// Called one more time.
 		sinon.assert.calledTwice( actionSpy );

--- a/tests/bindings/clickoutsidehandler.js
+++ b/tests/bindings/clickoutsidehandler.js
@@ -38,7 +38,7 @@ describe( 'clickOutsideHandler', () => {
 		document.body.removeChild( contextElement2 );
 	} );
 
-	it( 'should fired callback after clicking out of context element when listener is active', () => {
+	it( 'should execute upon #mousedown outside of the contextElements (activator is active)', () => {
 		activator.returns( true );
 
 		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
@@ -46,7 +46,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.calledOnce( actionSpy );
 	} );
 
-	it( 'should not fired callback after clicking out of context element when listener is not active', () => {
+	it( 'should not execute upon #mousedown outside of the contextElements (activator is inactive)', () => {
 		activator.returns( false );
 
 		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
@@ -54,7 +54,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.notCalled( actionSpy );
 	} );
 
-	it( 'should not fired callback after clicking on context element when listener is active', () => {
+	it( 'should not execute upon #mousedown from one of the contextElements (activator is active)', () => {
 		activator.returns( true );
 
 		contextElement1.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
@@ -64,7 +64,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.notCalled( actionSpy );
 	} );
 
-	it( 'should not fired callback after clicking on context element when listener is not active', () => {
+	it( 'should not execute upon #mousedown from one of the contextElements (activator is inactive)', () => {
 		activator.returns( false );
 
 		contextElement1.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
@@ -74,7 +74,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.notCalled( actionSpy );
 	} );
 
-	it( 'should listen when model initial `ifActive` value was `true`', () => {
+	it( 'should execute if the activator function returns `true`', () => {
 		const spy = testUtils.sinon.spy();
 
 		activator.returns( true );
@@ -91,7 +91,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.calledOnce( spy );
 	} );
 
-	it( 'should not listen when model initial `ifActive` value was `false`', () => {
+	it( 'should not execute if the activator function returns `false`', () => {
 		const spy = testUtils.sinon.spy();
 
 		activator.returns( false );
@@ -108,7 +108,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.notCalled( spy );
 	} );
 
-	it( 'should react on model `ifActive` property change', () => {
+	it( 'should react to the activator\'s return value change', () => {
 		activator.returns( true );
 
 		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
@@ -130,7 +130,7 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.calledTwice( actionSpy );
 	} );
 
-	it( 'should not execute the callback if one of #contextElements contains the DOM event target', () => {
+	it( 'should not execute if one of contextElements contains the DOM event target', () => {
 		const target = document.createElement( 'div' );
 		activator.returns( true );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `clickOutsideHandler` helper should use `mousedown` instead of `mouseup` event. Closes #281.

---

Should be merged with related branches:
* https://github.com/ckeditor/ckeditor5-image/tree/t/ckeditor5-ui/281
* https://github.com/ckeditor/ckeditor5-link/tree/t/ckeditor5-ui/281