### PR TITLE
ButtonView#tooltip can be added and removed after ButtonView initialization.

### DIFF
--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -147,17 +147,18 @@ export default class ButtonView extends View {
 		);
 
 		/**
-		 * Icon of the button view.
-		 *
-		 * @readonly
-		 * @member {module:ui/icon/iconview~IconView} #iconView
-		 */
-
-		/**
 		 * Tooltip of the button view.
 		 *
 		 * @readonly
 		 * @member {module:ui/tooltip/tooltipview~TooltipView} #tooltipView
+		 */
+		this.tooltipView = this._createTooltipView();
+
+		/**
+		 * Icon of the button view.
+		 *
+		 * @readonly
+		 * @member {module:ui/icon/iconview~IconView} #iconView
 		 */
 
 		const bind = this.bindTemplate;
@@ -190,7 +191,8 @@ export default class ButtonView extends View {
 							text: bind.to( 'label' )
 						}
 					]
-				}
+				},
+				this.tooltipView
 			],
 
 			on: {
@@ -233,17 +235,6 @@ export default class ButtonView extends View {
 			this.addChildren( iconView );
 		}
 
-		if ( this.tooltip ) {
-			const tooltipView = this.tooltipView = new TooltipView();
-
-			tooltipView.bind( 'text' ).to( this, '_tooltipString' );
-			tooltipView.bind( 'position' ).to( this, 'tooltipPosition' );
-			this.element.appendChild( tooltipView.element );
-
-			// Make sure the tooltip will be destroyed along with the button.
-			this.addChildren( tooltipView );
-		}
-
 		super.init();
 	}
 
@@ -252,6 +243,21 @@ export default class ButtonView extends View {
 	 */
 	focus() {
 		this.element.focus();
+	}
+
+	/**
+	 * Creates TooltipView instance and bind with button properties.
+	 *
+	 * @private
+	 * @returns {TooltipView}
+	 */
+	_createTooltipView() {
+		const tooltipView = new TooltipView();
+
+		tooltipView.bind( 'text' ).to( this, '_tooltipString' );
+		tooltipView.bind( 'position' ).to( this, 'tooltipPosition' );
+
+		return tooltipView;
 	}
 
 	/**
@@ -277,12 +283,12 @@ export default class ButtonView extends View {
 
 				if ( tooltip instanceof Function ) {
 					return tooltip( label, keystroke );
-				} else if ( tooltip === true ) {
+				} else {
 					return `${ label }${ keystroke ? ` (${ keystroke })` : '' }`;
 				}
 			}
 		}
 
-		return false;
+		return '';
 	}
 }

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -249,7 +249,7 @@ export default class ButtonView extends View {
 	 * Creates TooltipView instance and bind with button properties.
 	 *
 	 * @private
-	 * @returns {TooltipView}
+	 * @returns {module:ui/tooltip/tooltipview~TooltipView}
 	 */
 	_createTooltipView() {
 		const tooltipView = new TooltipView();

--- a/src/tooltip/tooltipview.js
+++ b/src/tooltip/tooltipview.js
@@ -28,7 +28,7 @@ export default class TooltipView extends View {
 		 * @observable
 		 * @member {String} #text
 		 */
-		this.set( 'text' );
+		this.set( 'text', '' );
 
 		/**
 		 * The position of the tooltip (south or north).
@@ -59,7 +59,7 @@ export default class TooltipView extends View {
 				class: [
 					'ck-tooltip',
 					bind.to( 'position', position => 'ck-tooltip_' + position ),
-					bind.to( 'text', value => !value ? 'ck-hidden' : '' )
+					bind.if( 'text', 'ck-hidden', value => !value.trim() )
 				]
 			},
 			children: [

--- a/src/tooltip/tooltipview.js
+++ b/src/tooltip/tooltipview.js
@@ -58,7 +58,8 @@ export default class TooltipView extends View {
 			attributes: {
 				class: [
 					'ck-tooltip',
-					bind.to( 'position', position => 'ck-tooltip_' + position )
+					bind.to( 'position', position => 'ck-tooltip_' + position ),
+					bind.to( 'text', value => !value ? 'ck-hidden' : '' )
 				]
 			},
 			children: [

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -107,7 +107,7 @@ describe( 'ButtonView', () => {
 					expect( view.tooltipView.text ).to.equal( 'bar (A)' );
 				} );
 
-				it( 'not render tooltip #tooltip value is false', () => {
+				it( 'not render tooltip text when #tooltip value is false', () => {
 					view.tooltip = false;
 					view.label = 'bar';
 					view.keystroke = 'A';

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -80,56 +80,12 @@ describe( 'ButtonView', () => {
 				view = new ButtonView( locale );
 			} );
 
-			it( 'is not initially set', () => {
-				expect( view.tooltipView ).to.be.undefined;
-				expect( view.element.childNodes ).to.have.length( 1 );
+			it( 'is initially set', () => {
+				expect( view.tooltipView ).to.be.instanceof( TooltipView );
+				expect( Array.from( view.template.children ) ).to.include( view.tooltipView );
 			} );
 
-			it( 'is not initially set (despite #label and #keystroke)', () => {
-				view.label = 'foo';
-				view.keystroke = 'A';
-				view.init();
-
-				expect( view.tooltipView ).to.be.undefined;
-			} );
-
-			it( 'is not set if neither `true`, String or Function', () => {
-				view.label = 'foo';
-				view.keystroke = 'A';
-				view.tooltip = false;
-				view.init();
-
-				expect( view.tooltipView ).to.be.undefined;
-
-				view.tooltip = 3;
-				expect( view.tooltipView ).to.be.undefined;
-
-				view.tooltip = new Date();
-				expect( view.tooltipView ).to.be.undefined;
-			} );
-
-			it( 'when set, is added to the DOM', () => {
-				view.tooltip = 'foo';
-				view.icon = 'bar';
-				view.init();
-
-				expect( view.element.childNodes ).to.have.length( 3 );
-				expect( view.element.childNodes[ 2 ] ).to.equal( view.tooltipView.element );
-				expect( view.tooltipView ).to.instanceOf( TooltipView );
-				expect( view.tooltipView.position ).to.equal( 's' );
-			} );
-
-			it( 'when set, is destroyed along with the view', () => {
-				view.tooltip = 'foo';
-				view.init();
-
-				const spy = sinon.spy( view.tooltipView, 'destroy' );
-
-				view.destroy();
-				sinon.assert.calledOnce( spy );
-			} );
-
-			it( 'when set, reacts to #tooltipPosition attribute', () => {
+			it( 'it reacts to #tooltipPosition attribute', () => {
 				view.tooltip = 'foo';
 				view.icon = 'bar';
 				view.init();
@@ -149,6 +105,15 @@ describe( 'ButtonView', () => {
 					view.init();
 
 					expect( view.tooltipView.text ).to.equal( 'bar (A)' );
+				} );
+
+				it( 'not render tooltip #tooltip value is false', () => {
+					view.tooltip = false;
+					view.label = 'bar';
+					view.keystroke = 'A';
+					view.init();
+
+					expect( view.tooltipView.text ).to.equal( '' );
 				} );
 
 				it( 'reacts to changes in #label and #keystroke', () => {
@@ -265,7 +230,7 @@ describe( 'ButtonView', () => {
 
 	describe( 'icon', () => {
 		it( 'is not initially set', () => {
-			expect( view.element.childNodes ).to.have.length( 1 );
+			expect( view.element.childNodes ).to.have.length( 2 );
 			expect( view.iconView ).to.be.undefined;
 		} );
 
@@ -274,7 +239,7 @@ describe( 'ButtonView', () => {
 			view.icon = 'foo';
 
 			view.init();
-			expect( view.element.childNodes ).to.have.length( 2 );
+			expect( view.element.childNodes ).to.have.length( 3 );
 			expect( view.element.childNodes[ 0 ] ).to.equal( view.iconView.element );
 
 			expect( view.iconView ).to.instanceOf( IconView );

--- a/tests/tooltip/tooltipview.js
+++ b/tests/tooltip/tooltipview.js
@@ -44,6 +44,14 @@ describe( 'TooltipView', () => {
 		} );
 
 		describe( 'class', () => {
+			it( 'should react on view#text', () => {
+				expect( view.element.classList.contains( 'ck-hidden' ) ).to.be.false;
+
+				view.text = '';
+
+				expect( view.element.classList.contains( 'ck-hidden' ) ).to.be.true;
+			} );
+
 			it( 'should react on view#position', () => {
 				expect( view.element.classList.contains( 'ck-tooltip_n' ) ).to.be.false;
 				expect( view.element.classList.contains( 'ck-tooltip_s' ) ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `ButtonView#tooltip` can be added and removed after `ButtonView` initialization. Closes #283.
