### PR TITLE
T/289: Changed type of collection used in "Template" class.

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -12,7 +12,6 @@
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import View from './view';
 import ViewCollection from './viewcollection';
 import cloneDeepWith from '@ckeditor/ckeditor5-utils/src/lib/lodash/cloneDeepWith';
@@ -1081,7 +1080,7 @@ function normalize( def ) {
 			normalizeAttributes( def.attributes );
 		}
 
-		const children = new Collection();
+		const children = new ViewCollection();
 
 		if ( def.children ) {
 			if ( isViewCollection( def.children ) ) {

--- a/tests/template.js
+++ b/tests/template.js
@@ -571,15 +571,15 @@ describe( 'Template', () => {
 				);
 			} );
 
-			// #289
+			// https://github.com/ckeditor/ckeditor5-ui/issues/289
 			it( 'does not throw when child does not have an "id" property', () => {
+				const strongView = getView( {
+					tag: 'strong'
+				} );
+
+				strongView.set( 'id' );
+
 				expect( () => {
-					const strongView = getView( {
-						tag: 'strong'
-					} );
-
-					strongView.set( 'id' );
-
 					getView( {
 						tag: 'div',
 						children: [

--- a/tests/template.js
+++ b/tests/template.js
@@ -9,7 +9,6 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { default as Template, TemplateToBinding, TemplateIfBinding } from '../src/template';
 import View from '../src/view';
 import ViewCollection from '../src/viewcollection';
-import InputTextView from '../src/inputtext/inputtextview';
 import Model from '../src/model';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
@@ -121,23 +120,6 @@ describe( 'Template', () => {
 
 			expect( tpl.attributes.a[ 0 ] ).to.equal( 'foo' );
 			expect( tpl.children.get( 0 ).tag ).to.equal( 'span' );
-		} );
-
-		it( 'does not throw when child does not have an "id" property', () => {
-			class DivView extends View {
-				constructor( locale ) {
-					super( locale );
-
-					this.template = new Template( {
-						tag: 'div',
-						children: [
-							new InputTextView( locale )
-						]
-					} );
-				}
-			}
-
-			expect( () => new DivView( {} ) ).to.not.throw( CKEditorError );
 		} );
 	} );
 
@@ -587,6 +569,24 @@ describe( 'Template', () => {
 				expect( normalizeHtml( tpl.render().outerHTML ) ).to.equal(
 					'<p><a></a><b></b><i>foo</i></p>'
 				);
+			} );
+
+			// #289
+			it( 'does not throw when child does not have an "id" property', () => {
+				expect( () => {
+					const strongView = getView( {
+						tag: 'strong'
+					} );
+
+					strongView.set( 'id' );
+
+					getView( {
+						tag: 'div',
+						children: [
+							strongView
+						]
+					} );
+				} ).to.not.throw();
 			} );
 		} );
 

--- a/tests/template.js
+++ b/tests/template.js
@@ -9,6 +9,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { default as Template, TemplateToBinding, TemplateIfBinding } from '../src/template';
 import View from '../src/view';
 import ViewCollection from '../src/viewcollection';
+import InputTextView from '../src/inputtext/inputtextview';
 import Model from '../src/model';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
@@ -120,6 +121,23 @@ describe( 'Template', () => {
 
 			expect( tpl.attributes.a[ 0 ] ).to.equal( 'foo' );
 			expect( tpl.children.get( 0 ).tag ).to.equal( 'span' );
+		} );
+
+		it( 'does not throw when child does not have an "id" property', () => {
+			class DivView extends View {
+				constructor( locale ) {
+					super( locale );
+
+					this.template = new Template( {
+						tag: 'div',
+						children: [
+							new InputTextView( locale )
+						]
+					} );
+				}
+			}
+
+			expect( () => new DivView( {} ) ).to.not.throw( CKEditorError );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `Template` class will not throw an error if its child does not have an `idProperty`. Closes #289.