### PR TITLE
Fix: Removed hacks from `BalloonPanelView` that made BalloonPanel unselectable

### DIFF
--- a/src/panel/balloon/balloonpanelview.js
+++ b/src/panel/balloon/balloonpanelview.js
@@ -13,7 +13,6 @@ import { getOptimalPosition } from '@ckeditor/ckeditor5-utils/src/dom/position';
 import isRange from '@ckeditor/ckeditor5-utils/src/dom/isrange';
 import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
 import toUnit from '@ckeditor/ckeditor5-utils/src/dom/tounit';
-import preventDefault from '../../bindings/preventdefault.js';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 const toPx = toUnit( 'px' );
@@ -130,15 +129,7 @@ export default class BalloonPanelView extends View {
 				}
 			},
 
-			children: this.content,
-
-			on: {
-				// https://github.com/ckeditor/ckeditor5-ui/issues/206
-				mousedown: preventDefault( this ),
-
-				// https://github.com/ckeditor/ckeditor5-ui/issues/243
-				selectstart: bind.to( evt => evt.preventDefault() )
-			}
+			children: this.content
 		} );
 	}
 

--- a/tests/panel/balloon/balloonpanelview.js
+++ b/tests/panel/balloon/balloonpanelview.js
@@ -121,27 +121,6 @@ describe( 'BalloonPanelView', () => {
 				expect( view.element.childNodes.length ).to.equal( 1 );
 			} );
 		} );
-
-		describe( 'event listeners', () => {
-			it( 'prevent default on #mousedown', () => {
-				const evt = new Event( 'mousedown', { bubbles: true } );
-				const spy = sinon.spy( evt, 'preventDefault' );
-
-				view.element.dispatchEvent( evt );
-				sinon.assert.calledOnce( spy );
-			} );
-
-			// https://github.com/ckeditor/ckeditor5-ui/issues/243
-			it( 'prevents default on #selectstart', () => {
-				const event = new Event( 'selectstart', { bubbles: true } );
-				const spy = sinon.spy( event, 'preventDefault' );
-				const child = document.createElement( 'div' );
-
-				view.element.appendChild( child );
-				child.dispatchEvent( event );
-				sinon.assert.calledOnce( spy );
-			} );
-		} );
 	} );
 
 	describe( 'show()', () => {

--- a/theme/components/panel/balloonpanel.scss
+++ b/theme/components/panel/balloonpanel.scss
@@ -2,8 +2,6 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 .ck-balloon-panel {
-	@include ck-unselectable();
-
 	display: none;
 	position: absolute;
 


### PR DESCRIPTION


### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Removed hacks from `BalloonPanelView` that made BalloonPanel content unselectable. Closes #294. Closes https://github.com/ckeditor/ckeditor5/issues/498.

---

### Additional information

@Mgsy could confirm this PR does not make a regression especially for this issues:
- https://github.com/ckeditor/ckeditor5-link/issues/126
- https://github.com/ckeditor/ckeditor5-link/issues/90
