### PR TITLE
t/303: Implemented View#removeChildren

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -275,6 +275,22 @@ export default class View {
 	}
 
 	/**
+	 * The opposite of {@link #addChildren}. Removes a child view from this view instance.
+	 * Once removed, the child is no longer managed by its parent, e.g. it can be safely used elsewhere,
+	 * becoming a child of another parent view.
+	 *
+	 * @see #addChildren
+	 * @param {module:ui/view~View|Iterable.<module:ui/view~View>} children Children views to be registered.
+	 */
+	removeChildren( children ) {
+		if ( !isIterable( children ) ) {
+			children = [ children ];
+		}
+
+		children.map( c => this._unboundChildren.remove( c ) );
+	}
+
+	/**
 	 * Initializes the view and child views located in {@link #_viewCollections}.
 	 */
 	init() {

--- a/src/view.js
+++ b/src/view.js
@@ -280,7 +280,7 @@ export default class View {
 	 * becoming a child of another parent view.
 	 *
 	 * @see #addChildren
-	 * @param {module:ui/view~View|Iterable.<module:ui/view~View>} children Children views to be registered.
+	 * @param {module:ui/view~View|Iterable.<module:ui/view~View>} children Child views to be removed.
 	 */
 	removeChildren( children ) {
 		if ( !isIterable( children ) ) {

--- a/tests/view.js
+++ b/tests/view.js
@@ -105,6 +105,39 @@ describe( 'View', () => {
 		} );
 	} );
 
+	describe( 'removeChildren()', () => {
+		beforeEach( () => {
+			setTestViewClass();
+			setTestViewInstance();
+		} );
+
+		it( 'should remove a single view from #_unboundChildren', () => {
+			const child1 = {};
+			const child2 = {};
+
+			view.addChildren( child1 );
+			view.addChildren( child2 );
+			expect( view._unboundChildren ).to.have.length( 2 );
+
+			view.removeChildren( child2 );
+			expect( view._unboundChildren ).to.have.length( 1 );
+			expect( view._unboundChildren.get( 0 ) ).to.equal( child1 );
+		} );
+
+		it( 'should support iterables', () => {
+			const child1 = {};
+			const child2 = {};
+			const child3 = {};
+
+			view.addChildren( [ child1, child2, child3 ] );
+			expect( view._unboundChildren ).to.have.length( 3 );
+
+			view.removeChildren( [ child2, child3 ] );
+			expect( view._unboundChildren ).to.have.length( 1 );
+			expect( view._unboundChildren.get( 0 ) ).to.equal( child1 );
+		} );
+	} );
+
 	describe( 'init()', () => {
 		beforeEach( createViewWithChildren );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented `View#removeChildren`, the opposite of `View#addChildren`. Closes #303.
