### PR TITLE
t/305: ContextualBalloon should remember position passed to #updatePosition

### DIFF
--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -192,7 +192,7 @@ export default class ContextualBalloon extends Plugin {
 			this._stack.get( this.visibleView ).position = position;
 		}
 
-		this.view.attachTo( this._getBalloonPosition() );
+		this.view.pin( this._getBalloonPosition() );
 	}
 
 	/**

--- a/tests/panel/balloon/contextualballoon.js
+++ b/tests/panel/balloon/contextualballoon.js
@@ -405,24 +405,24 @@ describe( 'ContextualBalloon', () => {
 				}
 			} );
 
-			balloon.view.attachTo.reset();
+			balloon.view.pin.reset();
 
 			balloon.updatePosition();
 
-			expect( balloon.view.attachTo.calledOnce );
-			sinon.assert.calledWithMatch( balloon.view.attachTo.firstCall, {
+			expect( balloon.view.pin.calledOnce );
+			sinon.assert.calledWithMatch( balloon.view.pin.firstCall, {
 				target: 'fake',
 				limiter: balloon.positionLimiter
 			} );
 		} );
 
 		it( 'should set given position to the currently visible view and use position from the first view in the stack #1', () => {
-			balloon.view.attachTo.reset();
+			balloon.view.pin.reset();
 
 			balloon.updatePosition( { target: 'new' } );
 
-			expect( balloon.view.attachTo.calledOnce );
-			sinon.assert.calledWithMatch( balloon.view.attachTo.firstCall, {
+			expect( balloon.view.pin.calledOnce );
+			sinon.assert.calledWithMatch( balloon.view.pin.firstCall, {
 				target: 'new',
 				limiter: balloon.positionLimiter
 			} );
@@ -436,12 +436,12 @@ describe( 'ContextualBalloon', () => {
 				}
 			} );
 
-			balloon.view.attachTo.reset();
+			balloon.view.pin.reset();
 
 			balloon.updatePosition( { target: 'new' } );
 
-			expect( balloon.view.attachTo.calledOnce );
-			sinon.assert.calledWithMatch( balloon.view.attachTo.firstCall, {
+			expect( balloon.view.pin.calledOnce );
+			sinon.assert.calledWithMatch( balloon.view.pin.firstCall, {
 				target: 'fake',
 				limiter: balloon.positionLimiter
 			} );
@@ -450,23 +450,23 @@ describe( 'ContextualBalloon', () => {
 
 			balloon.updatePosition();
 
-			expect( balloon.view.attachTo.calledTwice );
-			sinon.assert.calledWithMatch( balloon.view.attachTo.secondCall, {
+			expect( balloon.view.pin.calledTwice );
+			sinon.assert.calledWithMatch( balloon.view.pin.secondCall, {
 				target: 'new',
 				limiter: balloon.positionLimiter
 			} );
 		} );
 
 		it( 'should use a given position limiter instead of the default one', () => {
-			balloon.view.attachTo.reset();
+			balloon.view.pin.reset();
 
 			balloon.updatePosition( {
 				target: 'new',
 				limiter: 'customLimiter'
 			} );
 
-			expect( balloon.view.attachTo.calledOnce );
-			sinon.assert.calledWithMatch( balloon.view.attachTo.firstCall, {
+			expect( balloon.view.pin.calledOnce );
+			sinon.assert.calledWithMatch( balloon.view.pin.firstCall, {
 				target: 'new',
 				limiter: 'customLimiter'
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `ContextualBalloon` should remember position passed to `#updatePosition`. Closes #305. Closes ckeditor/ckeditor5-image#141.
