### PR TITLE
Adding z-index to sticky panel when position: fixed is applied

### DIFF
--- a/theme/components/panel/stickypanel.scss
+++ b/theme/components/panel/stickypanel.scss
@@ -4,7 +4,7 @@
 @include ck-editor {
 	.ck-sticky-panel {
 		&.ck-sticky-panel_sticky {
-			z-index: ck-z( 'modal' );
+			z-index: ck-z( 'modal' ); // #315
 			position: fixed;
 			top: 0;
 

--- a/theme/components/panel/stickypanel.scss
+++ b/theme/components/panel/stickypanel.scss
@@ -4,6 +4,7 @@
 @include ck-editor {
 	.ck-sticky-panel {
 		&.ck-sticky-panel_sticky {
+			z-index: ck-z( 'modal' );
 			position: fixed;
 			top: 0;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed sticky panel positioning when above images. Closes #315.

---

### Additional information

Sticky panel which holds the toolbar have `position:fixed` applied, so the elements inside editor with `position:relative` (images for example) are positioned above the sticky panel. Browser compares `z-index` of the sticky panel (which is not set) instead of panel's `z-index: 999`.