### PR TITLE
Fix: Use proper translations used to prevent blurry icons in toolbar …

### DIFF
--- a/theme/components/dropdown/dropdown.css
+++ b/theme/components/dropdown/dropdown.css
@@ -19,7 +19,7 @@
 
 		position: absolute;
 		top: 50%;
-		transform: translate( 0, -50% );
+		transform: translate3d( 0, -50%, 0 );
 	}
 
 	/* Dropdown button should span horizontally, e.g. in vertical toolbars */
@@ -44,9 +44,12 @@
 
 	position: absolute;
 	left: 0px;
-	transform: translateY( 100% );
+	transform: translate3d( 0, 100%, 0 );
 }
 
 .ck-dropdown__panel-visible {
 	display: inline-block;
+
+	/* This will prevent blurry icons in dropdown on Firefox. See #340. */
+	will-change: transform;
 }

--- a/theme/components/icon/icon.css
+++ b/theme/components/icon/icon.css
@@ -11,6 +11,9 @@ svg.ck-icon {
 	/* Inherit cursor style (#5). */
 	cursor: inherit;
 
+	/* This will prevent blurry icons on Firefox. See #340. */
+	will-change: transform;
+
 	& * {
 		/* Inherit cursor style (#5). */
 		cursor: inherit;


### PR DESCRIPTION
…on Firefox.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Use proper translations used to prevent blurry icons in toolbar on Firefox. Closes #340. Closes ckeditor/ckeditor5#668.

---

### Additional information

* As discussed in https://github.com/ckeditor/ckeditor5/issues/668#issuecomment-344846429 I've changed some `transformY` to `transform3d` and added `will-change` where transformation is already applied.
