### PR TITLE
Align code to changed config.lang to config.languages

### DIFF
--- a/src/editorui/boxed/boxededitoruiview.js
+++ b/src/editorui/boxed/boxededitoruiview.js
@@ -57,7 +57,7 @@ export default class BoxedEditorUIView extends EditorUIView {
 				],
 				role: 'application',
 				dir: 'ltr',
-				language: locale.language,
+				lang: locale.language,
 				'aria-labelledby': `cke-editor__aria-label_${ ariaLabelUid }`
 			},
 

--- a/src/editorui/boxed/boxededitoruiview.js
+++ b/src/editorui/boxed/boxededitoruiview.js
@@ -57,7 +57,7 @@ export default class BoxedEditorUIView extends EditorUIView {
 				],
 				role: 'application',
 				dir: 'ltr',
-				lang: locale.lang,
+				language: locale.language,
 				'aria-labelledby': `cke-editor__aria-label_${ ariaLabelUid }`
 			},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Aligned code to changes (`config.lang` to `config.languages`). Part of the Translation Service v2 (ckeditor/ckeditor5#624).
