### PR TITLE
t/176: Added the .ck-content CSS class to the EditableUIView

### DIFF
--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -36,6 +36,7 @@ export default class EditableUIView extends View {
 			attributes: {
 				class: [
 					bind.to( 'isFocused', value => value ? 'ck-focused' : 'ck-blurred' ),
+					'ck',
 					'ck-editor__editable',
 					'ck-content',
 					'ck-rounded-corners'

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -37,6 +37,7 @@ export default class EditableUIView extends View {
 				class: [
 					bind.to( 'isFocused', value => value ? 'ck-focused' : 'ck-blurred' ),
 					'ck-editor__editable',
+					'ck-content',
 					'ck-rounded-corners'
 				],
 				contenteditable: bind.to( 'isReadOnly', value => !value ),

--- a/tests/editableui/editableuiview.js
+++ b/tests/editableui/editableuiview.js
@@ -35,6 +35,7 @@ describe( 'EditableUIView', () => {
 
 			view.render();
 			expect( view.element ).to.equal( view.editableElement );
+			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-editor__editable' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-content' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-rounded-corners' ) ).to.be.true;

--- a/tests/editableui/editableuiview.js
+++ b/tests/editableui/editableuiview.js
@@ -36,6 +36,7 @@ describe( 'EditableUIView', () => {
 			view.render();
 			expect( view.element ).to.equal( view.editableElement );
 			expect( view.element.classList.contains( 'ck-editor__editable' ) ).to.be.true;
+			expect( view.element.classList.contains( 'ck-content' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-rounded-corners' ) ).to.be.true;
 			expect( view.externalElement ).to.be.undefined;
 			expect( view.isRendered ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added the `.ck-content` CSS class to the `EditableUIView`. Closes #176.

---

### Additional information

To be merged along with https://github.com/ckeditor/ckeditor5/compare/t/ckeditor5-ui/176?expand=1.
