### PR TITLE
t/112: CSS classes should be prefixed with ck- instead of cke-

### DIFF
--- a/src/editorui/boxed/boxededitoruiview.js
+++ b/src/editorui/boxed/boxededitoruiview.js
@@ -67,7 +67,7 @@ export default class BoxedEditorUIView extends EditorUIView {
 				role: 'application',
 				dir: 'ltr',
 				lang: locale.language,
-				'aria-labelledby': `cke-editor__aria-label_${ ariaLabelUid }`
+				'aria-labelledby': `ck-editor__aria-label_${ ariaLabelUid }`
 			},
 
 			children: [
@@ -106,8 +106,8 @@ export default class BoxedEditorUIView extends EditorUIView {
 
 		voiceLabel.extendTemplate( {
 			attributes: {
-				id: `cke-editor__aria-label_${ ariaLabelUid }`,
-				class: 'cke-voice-label'
+				id: `ck-editor__aria-label_${ ariaLabelUid }`,
+				class: 'ck-voice-label'
 			}
 		} );
 

--- a/tests/editorui/boxed/boxededitoruiview.js
+++ b/tests/editorui/boxed/boxededitoruiview.js
@@ -32,13 +32,13 @@ describe( 'BoxedEditorUIView', () => {
 			expect( view.element.classList.contains( 'ck-rounded-corners' ) ).to.be.true;
 			expect( element.attributes[ 'aria-labelledby' ].value )
 				.to.equal( view.element.firstChild.id )
-				.to.match( /^cke-editor__aria-label_\w+$/ );
+				.to.match( /^ck-editor__aria-label_\w+$/ );
 		} );
 
 		it( 'bootstraps the voice label from template', () => {
 			const voiceLabel = view.element.firstChild;
 
-			expect( voiceLabel.classList.contains( 'cke-voice-label' ) ).to.be.true;
+			expect( voiceLabel.classList.contains( 'ck-voice-label' ) ).to.be.true;
 			expect( voiceLabel.textContent ).to.equal( 'Rich Text Editor' );
 		} );
 

--- a/theme/components/label/label.css
+++ b/theme/components/label/label.css
@@ -7,6 +7,6 @@
 	display: block;
 }
 
-.cke-voice-label {
+.ck-voice-label {
 	display: none;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: CSS classes should be prefixed with `ck-` instead of `cke-`. Closes #112.