### PR TITLE
Removed `.ck-editor-toolbar` and `.ck-editor-toolbar-container` classes.

### DIFF
--- a/src/toolbar/contextual/contextualtoolbar.js
+++ b/src/toolbar/contextual/contextualtoolbar.js
@@ -53,7 +53,6 @@ export default class ContextualToolbar extends Plugin {
 		this.toolbarView.extendTemplate( {
 			attributes: {
 				class: [
-					'ck-editor-toolbar',
 					'ck-toolbar_floating'
 				]
 			}
@@ -178,7 +177,7 @@ export default class ContextualToolbar extends Plugin {
 		this._balloon.add( {
 			view: this.toolbarView,
 			position: this._getBalloonPositionData(),
-			balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container'
+			balloonClassName: 'ck-toolbar-container'
 		} );
 	}
 

--- a/tests/toolbar/contextual/contextualtoolbar.js
+++ b/tests/toolbar/contextual/contextualtoolbar.js
@@ -66,7 +66,6 @@ describe( 'ContextualToolbar', () => {
 		expect( contextualToolbar ).to.instanceOf( Plugin );
 		expect( contextualToolbar ).to.instanceOf( ContextualToolbar );
 		expect( contextualToolbar.toolbarView ).to.instanceof( ToolbarView );
-		expect( contextualToolbar.toolbarView.element.classList.contains( 'ck-editor-toolbar' ) ).to.be.true;
 		expect( contextualToolbar.toolbarView.element.classList.contains( 'ck-toolbar_floating' ) ).to.be.true;
 	} );
 
@@ -183,7 +182,7 @@ describe( 'ContextualToolbar', () => {
 
 			sinon.assert.calledWith( balloonAddSpy, {
 				view: contextualToolbar.toolbarView,
-				balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container',
+				balloonClassName: 'ck-toolbar-container',
 				position: {
 					target: sinon.match.func,
 					positions: [
@@ -226,7 +225,7 @@ describe( 'ContextualToolbar', () => {
 
 			sinon.assert.calledWithExactly( balloonAddSpy, {
 				view: contextualToolbar.toolbarView,
-				balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container',
+				balloonClassName: 'ck-toolbar-container',
 				position: {
 					target: sinon.match.func,
 					positions: [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

BREAKING CHANGE:  Removed `.ck-editor-toolbar` class in `ToolbarView`  and `.ck-editor-toolbar-container` class in `balloonClassName`.

---

### Additional information

* A piece of https://github.com/ckeditor/ckeditor5-theme-lark/issues/135
