### PR TITLE
t/ckeditor5-theme-lark/134: Added a CSS class to the `SplitButtonView` when the arrow is on

### DIFF
--- a/src/dropdown/button/splitbuttonview.js
+++ b/src/dropdown/button/splitbuttonview.js
@@ -109,7 +109,8 @@ export default class SplitButtonView extends View {
 			attributes: {
 				class: [
 					'ck-splitbutton',
-					bind.if( 'isVisible', 'ck-hidden', value => !value )
+					bind.if( 'isVisible', 'ck-hidden', value => !value ),
+					this.arrowView.bindTemplate.if( 'isOn', 'ck-splitbutton_open' )
 				]
 			},
 

--- a/tests/dropdown/button/splitbuttonview.js
+++ b/tests/dropdown/button/splitbuttonview.js
@@ -52,6 +52,14 @@ describe( 'SplitButtonView', () => {
 			expect( view.actionView.element.classList.contains( 'ck-hidden' ) ).to.be.false;
 		} );
 
+		it( 'binds arrowView#isOn to the template', () => {
+			view.arrowView.isOn = true;
+			expect( view.element.classList.contains( 'ck-splitbutton_open' ) ).to.be.true;
+
+			view.arrowView.isOn = false;
+			expect( view.element.classList.contains( 'ck-splitbutton_open' ) ).to.be.false;
+		} );
+
 		describe( 'activates keyboard navigation for the toolbar', () => {
 			it( 'so "arrowright" on view#arrowView does nothing', () => {
 				const keyEvtData = {

--- a/theme/components/dropdown/splitbutton.css
+++ b/theme/components/dropdown/splitbutton.css
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+@import "../tooltip/mixins/_tooltip.css";
+
 .ck-splitbutton {
 	/* Enable font size inheritance, which allows fluid UI scaling. */
 	font-size: inherit;
@@ -10,4 +12,9 @@
 	& .ck-splitbutton__action:focus {
 		z-index: calc(var(--ck-z-default) + 1);
 	}
+}
+
+/* Disable tooltips for the buttons when the button is "open" */
+.ck-splitbutton.ck-splitbutton_open > .ck-button {
+	@mixin ck-tooltip_disabled;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added a CSS class to the `SplitButtonView` when the arrow is on (see ckeditor/ckeditor5-theme-lark#134).