### PR TITLE
Made ComponentFactory.names() return original componenent name.

### DIFF
--- a/src/componentfactory.js
+++ b/src/componentfactory.js
@@ -62,7 +62,9 @@ export default class ComponentFactory {
 	 * @returns {Iterable.<String>}
 	 */
 	* names() {
-		yield* this._components.keys();
+		for ( const value of this._components.values() ) {
+			yield value.originalName;
+		}
 	}
 
 	/**
@@ -87,7 +89,7 @@ export default class ComponentFactory {
 			);
 		}
 
-		this._components.set( getNormalized( name ), callback );
+		this._components.set( getNormalized( name ), { callback, originalName: name } );
 	}
 
 	/**
@@ -115,7 +117,7 @@ export default class ComponentFactory {
 			);
 		}
 
-		return this._components.get( getNormalized( name ) )( this.editor.locale );
+		return this._components.get( getNormalized( name ) ).callback( this.editor.locale );
 	}
 
 	/**

--- a/tests/componentfactory.js
+++ b/tests/componentfactory.js
@@ -33,7 +33,7 @@ describe( 'ComponentFactory', () => {
 			factory.add( 'bar', () => {} );
 			factory.add( 'Baz', () => {} );
 
-			expect( Array.from( factory.names() ) ).to.have.members( [ 'foo', 'bar', 'baz' ] );
+			expect( Array.from( factory.names() ) ).to.have.members( [ 'foo', 'bar', 'Baz' ] );
 		} );
 	} );
 
@@ -52,6 +52,12 @@ describe( 'ComponentFactory', () => {
 			expect( () => {
 				factory.add( 'foo', () => {} );
 			} ).to.throw( CKEditorError, /^componentfactory-item-exists/ );
+		} );
+
+		it( 'does not normalize component names', () => {
+			factory.add( 'FoO', () => {} );
+
+			expect( Array.from( factory.names() ) ).to.have.members( [ 'FoO' ] );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `ComponentFactory.names()` will return original component names (instead of normalized names). Closes #376.
