### PR TITLE
t/ckedtor5/920: Clicking the button once on an iOS device should execute an action

### DIFF
--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -11,6 +11,7 @@ import View from '../view';
 import IconView from '../icon/iconview';
 import TooltipView from '../tooltip/tooltipview';
 
+import env from '@ckeditor/ckeditor5-utils/src/env';
 import { getEnvKeystrokeText } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
 import '../../theme/components/button/button.css';
@@ -225,7 +226,8 @@ export default class ButtonView extends View {
 	 * @returns {String}
 	 */
 	_getTooltipString( tooltip, label, keystroke ) {
-		if ( tooltip ) {
+		// https://github.com/ckeditor/ckeditor5/issues/920
+		if ( tooltip && !env.isIOS ) {
 			if ( typeof tooltip == 'string' ) {
 				return tooltip;
 			} else {

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -11,6 +11,7 @@ import IconView from '../../src/icon/iconview';
 import TooltipView from '../../src/tooltip/tooltipview';
 import View from '../../src/view';
 import ViewCollection from '../../src/viewcollection';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 testUtils.createSinonSandbox();
 
@@ -110,6 +111,20 @@ describe( 'ButtonView', () => {
 
 				view.tooltipPosition = 'n';
 				expect( view.tooltipView.position ).to.equal( 'n' );
+			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/920
+			it( 'is disabled on iOS devices', () => {
+				const initialEnvIOS = env.isIOS;
+				env.isIOS = true;
+
+				view = new ButtonView( locale );
+				view.tooltip = 'foo';
+				view.render();
+
+				expect( view.tooltipView.text ).to.equal( '' );
+
+				env.isIOS = initialEnvIOS;
 			} );
 
 			describe( 'defined as a Boolean', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Clicking the button once on an iOS device should execute an action. Closes ckeditor/ckeditor5#920.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-utils/pull/231
