### PR TITLE
t/ckeditor5-table/28: Made the ContextualBalloon always use the position of the topmost view in the stack

### DIFF
--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -10,7 +10,6 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import BalloonPanelView from './balloonpanelview';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
-import first from '@ckeditor/ckeditor5-utils/src/first';
 
 /**
  * Provides the common contextual balloon panel for the editor.
@@ -213,14 +212,14 @@ export default class ContextualBalloon extends Plugin {
 	}
 
 	/**
-	 * Returns position options of the first view in the stack.
+	 * Returns position options of the last view in the stack.
 	 * This keeps the balloon in the same position when view is changed.
 	 *
 	 * @private
 	 * @returns {module:utils/dom/position~Options}
 	 */
 	_getBalloonPosition() {
-		let position = first( this._stack.values() ).position;
+		let position = Array.from( this._stack.values() ).pop().position;
 
 		// Use the default limiter if none has been specified.
 		if ( position && !position.limiter ) {

--- a/tests/panel/balloon/contextualballoon.js
+++ b/tests/panel/balloon/contextualballoon.js
@@ -258,7 +258,7 @@ describe( 'ContextualBalloon', () => {
 			expect( balloon.view.content.get( 0 ) ).to.deep.equal( viewB );
 		} );
 
-		it( 'should keep balloon at the same position after adding next view', () => {
+		it( 'should use the position of the last view in the stack', () => {
 			balloon.add( {
 				view: viewB,
 				position: { target: 'other' }
@@ -272,7 +272,7 @@ describe( 'ContextualBalloon', () => {
 			} );
 
 			sinon.assert.calledWithMatch( balloon.view.pin.secondCall, {
-				target: 'fake',
+				target: 'other',
 				limiter: balloon.positionLimiter
 			} );
 		} );
@@ -399,7 +399,7 @@ describe( 'ContextualBalloon', () => {
 	} );
 
 	describe( 'updatePosition()', () => {
-		it( 'should attach balloon to the target using position option from the first view in the stack', () => {
+		it( 'should attach balloon to the target using position option from the last view in the stack', () => {
 			balloon.add( {
 				view: viewB,
 				position: {
@@ -413,7 +413,7 @@ describe( 'ContextualBalloon', () => {
 
 			expect( balloon.view.pin.calledOnce );
 			sinon.assert.calledWithMatch( balloon.view.pin.firstCall, {
-				target: 'fake',
+				target: 'other',
 				limiter: balloon.positionLimiter
 			} );
 		} );
@@ -444,7 +444,7 @@ describe( 'ContextualBalloon', () => {
 
 			expect( balloon.view.pin.calledOnce );
 			sinon.assert.calledWithMatch( balloon.view.pin.firstCall, {
-				target: 'fake',
+				target: 'new',
 				limiter: balloon.positionLimiter
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Made the ContextualBalloon always use the position of the topmost view in the stack (see: ckeditor/ckeditor5-table#28).

---

### Additional information

* Required by https://github.com/ckeditor/ckeditor5-table/pull/33.

**Note:** This will change the behavior of the balloons when one should use the position of another. Check out http://localhost:8125/ckeditor5-ui/tests/manual/contextualballoon/contextualballoon.html to see the difference. 

I had to disable this feature because it attached the link balloon to the table instead of an actual link in the content. Generally speaking, the feature was broken in the first place and never had a chance to work properly as the number of use cases (balloons) increased.

So this is more a temp workaround sacrificing a very particular behaviour (BalloonToolbar<->LinkUI) to fix a very annoying bug somwhere else (in tables). The right solution will come in https://github.com/ckeditor/ckeditor5/issues/852.