### PR TITLE
Fix: Hide BlockToolbar when the editor is blurred.

### DIFF
--- a/src/toolbar/block/blocktoolbar.js
+++ b/src/toolbar/block/blocktoolbar.js
@@ -162,10 +162,15 @@ export default class BlockToolbar extends Plugin {
 
 		toolbarView.extendTemplate( {
 			attributes: {
-				class: [
-					// https://github.com/ckeditor/ckeditor5-editor-inline/issues/11
-					'ck-toolbar_floating'
-				]
+				// https://github.com/ckeditor/ckeditor5-editor-inline/issues/11
+				class: [ 'ck-toolbar_floating' ]
+			}
+		} );
+
+		// When toolbar lost focus then panel should hide.
+		toolbarView.focusTracker.on( 'change:isFocused', ( evt, name, is ) => {
+			if ( !is ) {
+				this._hidePanel();
 			}
 		} );
 

--- a/src/toolbar/block/blocktoolbar.js
+++ b/src/toolbar/block/blocktoolbar.js
@@ -242,17 +242,15 @@ export default class BlockToolbar extends Plugin {
 		const model = editor.model;
 		const view = editor.editing.view;
 
-		// Hides the button when editor is not focused.
+		// Hides the button when the editor is not focused.
 		if ( !editor.ui.focusTracker.isFocused ) {
 			this._hideButton();
 
 			return;
 		}
 
-		// Hides button when the editor switches to the read-only mode.
-		// Do not hide when panel is already visible to avoid a confusing UX when the panel
-		// unexpectedly disappears.
-		if ( editor.isReadOnly && !this.panelView.isVisible ) {
+		// Hides the button when the editor switches to the read-only mode.
+		if ( editor.isReadOnly ) {
 			this._hideButton();
 
 			return;

--- a/tests/toolbar/block/blocktoolbar.js
+++ b/tests/toolbar/block/blocktoolbar.js
@@ -5,7 +5,6 @@
 /* global document, window, Event */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
-import ClickObserver from '@ckeditor/ckeditor5-engine/src/view/observer/clickobserver';
 
 import BlockToolbar from '../../../src/toolbar/block/blocktoolbar';
 import ToolbarView from '../../../src/toolbar/toolbarview';
@@ -39,6 +38,7 @@ describe( 'BlockToolbar', () => {
 		} ).then( newEditor => {
 			editor = newEditor;
 			blockToolbar = editor.plugins.get( BlockToolbar );
+			editor.ui.focusTracker.isFocused = true;
 		} );
 	} );
 
@@ -49,10 +49,6 @@ describe( 'BlockToolbar', () => {
 
 	it( 'should have pluginName property', () => {
 		expect( BlockToolbar.pluginName ).to.equal( 'BlockToolbar' );
-	} );
-
-	it( 'should register a click observer', () => {
-		expect( editor.editing.view.getObserver( ClickObserver ) ).to.be.instanceOf( ClickObserver );
 	} );
 
 	describe( 'child views', () => {
@@ -70,7 +66,7 @@ describe( 'BlockToolbar', () => {
 			} );
 
 			it( 'should add the #panelView to ui.focusTracker', () => {
-				expect( editor.ui.focusTracker.isFocused ).to.be.false;
+				editor.ui.focusTracker.isFocused = false;
 
 				blockToolbar.panelView.element.dispatchEvent( new Event( 'focus' ) );
 
@@ -149,7 +145,7 @@ describe( 'BlockToolbar', () => {
 			} );
 
 			it( 'should add the #buttonView to the ui.focusTracker', () => {
-				expect( editor.ui.focusTracker.isFocused ).to.be.false;
+				editor.ui.focusTracker.isFocused = false;
 
 				blockToolbar.buttonView.element.dispatchEvent( new Event( 'focus' ) );
 
@@ -377,7 +373,7 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.panelView.isVisible ).to.be.true;
 		} );
 
-		it( 'should hide the UI when editor switches to readonly when the panel is not visible', () => {
+		it( 'should hide the UI when editor switched to readonly when the panel is not visible', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
 			blockToolbar.buttonView.isVisible = true;
@@ -389,16 +385,46 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.panelView.isVisible ).to.be.false;
 		} );
 
-		it( 'should not hide button when the editor switches to readonly when the panel is visible', () => {
+		it( 'should show the button when the editor switched from readonly', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
-			blockToolbar.buttonView.isVisible = true;
-			blockToolbar.panelView.isVisible = true;
+			expect( blockToolbar.buttonView.isVisible ).to.true;
 
 			editor.isReadOnly = true;
 
+			expect( blockToolbar.buttonView.isVisible ).to.false;
+
+			editor.isReadOnly = false;
+
 			expect( blockToolbar.buttonView.isVisible ).to.be.true;
-			expect( blockToolbar.panelView.isVisible ).to.be.true;
+		} );
+
+		it( 'should show/hide the button on editor focus/blur', () => {
+			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
+
+			editor.ui.focusTracker.isFocused = true;
+
+			expect( blockToolbar.buttonView.isVisible ).to.true;
+
+			editor.ui.focusTracker.isFocused = false;
+
+			expect( blockToolbar.buttonView.isVisible ).to.false;
+
+			editor.ui.focusTracker.isFocused = true;
+
+			expect( blockToolbar.buttonView.isVisible ).to.true;
+		} );
+
+		it( 'should hide the UI when editor switched to readonly when the panel is not visible', () => {
+			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
+
+			blockToolbar.buttonView.isVisible = true;
+			blockToolbar.panelView.isVisible = false;
+
+			editor.isReadOnly = true;
+
+			expect( blockToolbar.buttonView.isVisible ).to.be.false;
+			expect( blockToolbar.panelView.isVisible ).to.be.false;
 		} );
 
 		it( 'should update the button position on browser resize only when the button is visible', () => {

--- a/tests/toolbar/block/blocktoolbar.js
+++ b/tests/toolbar/block/blocktoolbar.js
@@ -365,7 +365,7 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.panelView.isVisible ).to.be.false;
 		} );
 
-		it( 'should not hide the open panel on a indirect selection change', () => {
+		it( 'should not hide the open panel on an indirect selection change', () => {
 			blockToolbar.panelView.isVisible = true;
 
 			editor.model.document.selection.fire( 'change:range', { directChange: false } );
@@ -373,11 +373,11 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.panelView.isVisible ).to.be.true;
 		} );
 
-		it( 'should hide the UI when editor switched to readonly when the panel is not visible', () => {
+		it( 'should hide the UI when editor switched to readonly', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
 			blockToolbar.buttonView.isVisible = true;
-			blockToolbar.panelView.isVisible = false;
+			blockToolbar.panelView.isVisible = true;
 
 			editor.isReadOnly = true;
 
@@ -385,7 +385,7 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.panelView.isVisible ).to.be.false;
 		} );
 
-		it( 'should show the button when the editor switched from readonly', () => {
+		it( 'should show the button when the editor switched back from readonly', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
 			expect( blockToolbar.buttonView.isVisible ).to.true;
@@ -399,7 +399,7 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.buttonView.isVisible ).to.be.true;
 		} );
 
-		it( 'should show/hide the button on editor focus/blur', () => {
+		it( 'should show/hide the button on the editor focus/blur', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
 			editor.ui.focusTracker.isFocused = true;
@@ -415,7 +415,7 @@ describe( 'BlockToolbar', () => {
 			expect( blockToolbar.buttonView.isVisible ).to.true;
 		} );
 
-		it( 'should hide the UI when editor switched to readonly when the panel is not visible', () => {
+		it( 'should hide the UI when the editor switched to the readonly when the panel is not visible', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
 			blockToolbar.buttonView.isVisible = true;

--- a/tests/toolbar/block/blocktoolbar.js
+++ b/tests/toolbar/block/blocktoolbar.js
@@ -133,6 +133,16 @@ describe( 'BlockToolbar', () => {
 
 				expect( blockToolbar.panelView.isVisible ).to.be.false;
 			} );
+
+			it( 'should hide the panel on toolbar blur', () => {
+				blockToolbar.buttonView.fire( 'execute' );
+
+				expect( blockToolbar.panelView.isVisible ).to.be.true;
+
+				blockToolbar.toolbarView.focusTracker.isFocused = false;
+
+				expect( blockToolbar.panelView.isVisible ).to.be.false;
+			} );
 		} );
 
 		describe( 'buttonView', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Hide BlockToolbar when the editor is blurred. Closes #408.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
