### PR TITLE
Hide the BalloonToolbar on editable blur

### DIFF
--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -52,8 +52,8 @@ export default class BalloonToolbar extends Plugin {
 		this.toolbarView = this._createToolbarView();
 
 		/**
-		 * Tracks focus of editable element and {@link #toolbarView}.
-		 * When both are not focused then toolbar should hide.
+		 * Tracks the focus of the {@link module:ui/editableui/editableuiview~EditableUIView#editableElement}
+		 * and the {@link #toolbarView}. When both are blurred then the toolbar should hide.
 		 *
 		 * @readonly
 		 * @type {module:utils:focustracker~FocusTracker}

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -81,11 +81,14 @@ export default class BalloonToolbar extends Plugin {
 		const editor = this.editor;
 		const selection = editor.model.document.selection;
 
-		// Show/hide the toolbar when on editable focus/blur.
-		this.listenTo( editor.editing.view.document, 'change:isFocused', ( evt, name, isFocused ) => {
-			if ( !isFocused && this._balloon.visibleView === this.toolbarView ) {
+		// Show/hide the toolbar on editable focus/blur.
+		this.listenTo( editor.editing.view.document, 'change:isFocused', ( evt, name, isEditableFocused ) => {
+			const isToolbarFocused = this.toolbarView.focusTracker.isFocused;
+			const isToolbarVisible = this._balloon.visibleView === this.toolbarView;
+
+			if ( !isEditableFocused && !isToolbarFocused && isToolbarVisible ) {
 				this.hide();
-			} else if ( isFocused ) {
+			} else if ( isEditableFocused ) {
 				this.show();
 			}
 		} );

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -48,17 +48,7 @@ export default class BalloonToolbar extends Plugin {
 		 *
 		 * @member {module:ui/toolbar/toolbarview~ToolbarView}
 		 */
-		this.toolbarView = new ToolbarView( editor.locale );
-
-		this.toolbarView.extendTemplate( {
-			attributes: {
-				class: [
-					'ck-toolbar_floating'
-				]
-			}
-		} );
-
-		this.toolbarView.render();
+		this.toolbarView = this._createToolbarView();
 
 		/**
 		 * The contextual balloon plugin instance.
@@ -99,6 +89,26 @@ export default class BalloonToolbar extends Plugin {
 		const factory = this.editor.ui.componentFactory;
 
 		this.toolbarView.fillFromConfig( config.items, factory );
+	}
+
+	/**
+	 * Creates the toolbar view instance.
+	 *
+	 * @private
+	 * @returns {module:ui/toolbar/toolbarview~ToolbarView}
+	 */
+	_createToolbarView() {
+		const toolbarView = new ToolbarView( this.editor.locale );
+
+		toolbarView.extendTemplate( {
+			attributes: {
+				class: [ 'ck-toolbar_floating' ]
+			}
+		} );
+
+		toolbarView.render();
+
+		return toolbarView;
 	}
 
 	/**

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -46,7 +46,7 @@ export default class BalloonToolbar extends Plugin {
 		/**
 		 * The toolbar view displayed in the balloon.
 		 *
-		 * @member {module:ui/toolbar/toolbarview~ToolbarView}
+		 * @type {module:ui/toolbar/toolbarview~ToolbarView}
 		 */
 		this.toolbarView = this._createToolbarView();
 
@@ -54,7 +54,7 @@ export default class BalloonToolbar extends Plugin {
 		 * The contextual balloon plugin instance.
 		 *
 		 * @private
-		 * @member {module:ui/panel/balloon/contextualballoon~ContextualBalloon}
+		 * @type {module:ui/panel/balloon/contextualballoon~ContextualBalloon}
 		 */
 		this._balloon = editor.plugins.get( ContextualBalloon );
 
@@ -65,7 +65,7 @@ export default class BalloonToolbar extends Plugin {
 		 * trailing debounced invocation on destroy.
 		 *
 		 * @private
-		 * @member {Function}
+		 * @type {Function}
 		 */
 		this._fireSelectionChangeDebounced = debounce( () => this.fire( '_selectionChangeDebounced' ), 200 );
 

--- a/tests/manual/tickets/418/1.html
+++ b/tests/manual/tickets/418/1.html
@@ -1,0 +1,31 @@
+<div class="wrapper">
+	<div id="editor">
+		<h2>The three greatest things you learn from traveling</h2>
+		<p>
+			Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons
+			I’ve learned over the years of traveling.
+		</p>
+
+		<h3>Appreciation of diversity</h3>
+		<p>
+			Getting used to an entirely different culture can be challenging. While it’s also nice to learn about
+			cultures online or from books, nothing comes close to experiencing cultural diversity in person.
+			You learn to appreciate each and every single one of the differences while you become more culturally fluid.
+		</p>
+	</div>
+</div>
+
+<style>
+	#editor {
+		margin: 0 auto;
+		max-width: 800px;
+	}
+
+	.wrapper {
+		padding: 50px 20px;
+	}
+
+	.ck-block-toolbar-button {
+		transform: translateX( -10px );
+	}
+</style>

--- a/tests/manual/tickets/418/1.js
+++ b/tests/manual/tickets/418/1.js
@@ -1,0 +1,45 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals window, document, console:false */
+
+import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import List from '@ckeditor/ckeditor5-list/src/list';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import HeadingButtonsUI from '@ckeditor/ckeditor5-heading/src/headingbuttonsui';
+import ParagraphButtonUI from '@ckeditor/ckeditor5-paragraph/src/paragraphbuttonui';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import Link from '@ckeditor/ckeditor5-link/src/link';
+
+import BlockToolbar from '../../../../src/toolbar/block/blocktoolbar';
+import BalloonToolbar from '../../../../src/toolbar/balloon/balloontoolbar';
+
+BalloonEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			Essentials,
+			List,
+			Paragraph,
+			Heading,
+			HeadingButtonsUI,
+			ParagraphButtonUI,
+			Bold,
+			Italic,
+			Link,
+			BlockToolbar,
+			BalloonToolbar
+		],
+		blockToolbar: [ 'paragraph', 'heading1', 'heading2', 'heading3', 'bulletedList', 'numberedList' ],
+		balloonToolbar: [ 'bold', 'italic', 'link' ]
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/tickets/418/1.md
+++ b/tests/manual/tickets/418/1.md
@@ -1,0 +1,5 @@
+## BlockToolbar and BalloonToolbar collision [#418](https://github.com/ckeditor/ckeditor5-ui/issues/418)
+
+- select some text, balloon toolbar should show up
+- click block toolbar button, balloon toolbar should hide
+- pres `Esc` to move focus back to editable, balloon toolbar should show up

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -149,7 +149,7 @@ describe( 'BalloonToolbar', () => {
 			expect( balloonToolbar.focusTracker ).to.instanceof( FocusTracker );
 		} );
 
-		it( 'it should track focus of #editableElement', () => {
+		it( 'it should track the focus of the #editableElement', () => {
 			expect( balloonToolbar.focusTracker.isFocused ).to.false;
 
 			editor.ui.view.editableElement.dispatchEvent( new Event( 'focus' ) );
@@ -157,7 +157,7 @@ describe( 'BalloonToolbar', () => {
 			expect( balloonToolbar.focusTracker.isFocused ).to.true;
 		} );
 
-		it( 'it should track focus of #toolbarView.element', () => {
+		it( 'it should track the focus of the toolbarView#element', () => {
 			expect( balloonToolbar.focusTracker.isFocused ).to.false;
 
 			balloonToolbar.toolbarView.element.dispatchEvent( new Event( 'focus' ) );
@@ -320,7 +320,7 @@ describe( 'BalloonToolbar', () => {
 			sinon.assert.calledOnce( balloonAddSpy );
 		} );
 
-		it( 'should not add #toolbarView to the #_balloon when the selection is collapsed', () => {
+		it( 'should not add the #toolbarView to the #_balloon when the selection is collapsed', () => {
 			setData( model, '<paragraph>b[]ar</paragraph>' );
 
 			balloonToolbar.show();
@@ -431,7 +431,7 @@ describe( 'BalloonToolbar', () => {
 			sinon.assert.notCalled( hidePanelSpy );
 		} );
 
-		it( 'should not show when selection stops changing when editable is blurred', () => {
+		it( 'should not show when the selection stops changing when the editable is blurred', () => {
 			sinon.assert.notCalled( showPanelSpy );
 			sinon.assert.notCalled( hidePanelSpy );
 

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -477,6 +477,25 @@ describe( 'BalloonToolbar', () => {
 			stub.restore();
 		} );
 
+		it( 'should not hide on editable blur when #toolbarView gets focus', () => {
+			editingView.document.isFocused = true;
+
+			balloonToolbar.fire( '_selectionChangeDebounced' );
+
+			const stub = sandbox.stub( balloon, 'visibleView' ).get( () => balloonToolbar.toolbarView );
+
+			sinon.assert.calledOnce( showPanelSpy );
+			sinon.assert.notCalled( hidePanelSpy );
+
+			balloonToolbar.toolbarView.focusTracker.isFocused = true;
+			editingView.document.isFocused = false;
+
+			sinon.assert.calledOnce( showPanelSpy );
+			sinon.assert.notCalled( hidePanelSpy );
+
+			stub.restore();
+		} );
+
 		it( 'should not hide on editable blur when #toolbarView is not visible', () => {
 			editingView.document.isFocused = true;
 

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -18,7 +18,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { stringify as viewStringify } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
-/* global document, setTimeout, window */
+/* global document, setTimeout, window, Event */
 
 describe( 'BalloonToolbar', () => {
 	let sandbox, editor, model, selection, editingView, balloonToolbar, balloon, editorElement;

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -297,6 +297,13 @@ describe( 'BalloonToolbar', () => {
 			sinon.assert.calledOnce( balloonAddSpy );
 		} );
 
+		it( 'should not add #toolbarView to the #_balloon when the selection is collapsed', () => {
+			setData( model, '<paragraph>b[]ar</paragraph>' );
+
+			balloonToolbar.show();
+			sinon.assert.notCalled( balloonAddSpy );
+		} );
+
 		it( 'should not add #toolbarView to the #_balloon when all components inside #toolbarView are disabled', () => {
 			Array.from( balloonToolbar.toolbarView.items ).forEach( item => {
 				item.isEnabled = false;
@@ -327,24 +334,19 @@ describe( 'BalloonToolbar', () => {
 				showSpy = sandbox.spy( balloonToolbar, 'show' );
 			} );
 
-			it( 'should not be called when the editor is not focused', () => {
+			it( 'should not be called when the editable is not focused', () => {
 				setData( model, '<paragraph>b[a]r</paragraph>' );
 				editingView.document.isFocused = false;
+				balloonToolbar.toolbarView.focusTracker.isFocused = false;
 
 				balloonToolbar.fire( '_selectionChangeDebounced' );
 				sinon.assert.notCalled( showSpy );
 			} );
 
-			it( 'should not be called when the selection is collapsed', () => {
-				setData( model, '<paragraph>b[]ar</paragraph>' );
-
-				balloonToolbar.fire( '_selectionChangeDebounced' );
-				sinon.assert.notCalled( showSpy );
-			} );
-
-			it( 'should be called when the selection is not collapsed and editor is focused', () => {
+			it( 'should be called when the editable is focused', () => {
 				setData( model, '<paragraph>b[a]r</paragraph>' );
 				editingView.document.isFocused = true;
+				balloonToolbar.toolbarView.focusTracker.isFocused = false;
 
 				balloonToolbar.fire( '_selectionChangeDebounced' );
 				sinon.assert.calledOnce( showSpy );
@@ -472,8 +474,8 @@ describe( 'BalloonToolbar', () => {
 			sinon.assert.calledOnce( hidePanelSpy );
 		} );
 
-		it( 'should hide if the editor loses focus', () => {
-			editor.ui.focusTracker.isFocused = true;
+		it( 'should hide when the editable loses focus', () => {
+			editor.editing.view.document.isFocused = true;
 
 			balloonToolbar.fire( '_selectionChangeDebounced' );
 
@@ -482,7 +484,7 @@ describe( 'BalloonToolbar', () => {
 			sinon.assert.calledOnce( showPanelSpy );
 			sinon.assert.notCalled( hidePanelSpy );
 
-			editor.ui.focusTracker.isFocused = false;
+			editor.editing.view.document.isFocused = false;
 
 			sinon.assert.calledOnce( showPanelSpy );
 			sinon.assert.calledOnce( hidePanelSpy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Hide the BalloonToolbar on editable blur. Closes #418.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
