### PR TITLE
t/394: Block toolbar improvements

### DIFF
--- a/theme/components/list/list.css
+++ b/theme/components/list/list.css
@@ -8,8 +8,6 @@
 .ck.ck-list {
 	@mixin ck-unselectable;
 
-	/* Crop the the items when the list has huge border-radius. */
-	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 
@@ -18,7 +16,10 @@
 		display: block;
 	}
 
-	& .ck-list__item:focus {
+	/* Make sure that whatever child of the list item gets focus, it remains on the
+	top. Thanks to that, styles like box-shadow, outline, etc. are not masked by
+	adjacent list items. */
+	& .ck-list__item > *:focus {
 		position: relative;
 		z-index: var(--ck-z-default);
 	}

--- a/theme/components/panel/balloonpanel.css
+++ b/theme/components/panel/balloonpanel.css
@@ -3,6 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
+:root {
+	/* Make sure the balloon arrow does not float over its children. */
+	--ck-balloon-panel-arrow-z-index: calc(var(--ck-z-default) - 3);
+}
+
 .ck.ck-balloon-panel {
 	display: none;
 	position: absolute;
@@ -17,31 +22,31 @@
 		}
 
 		&::before {
-			z-index: var(--ck-z-default);
+			z-index: var(--ck-balloon-panel-arrow-z-index);
 		}
 
 		&::after {
-			z-index: calc(var(--ck-z-default) + 1 );
+			z-index: calc(var(--ck-balloon-panel-arrow-z-index) + 1);
 		}
 	}
 
 	&[class*="arrow_n"] {
 		&::before {
-			z-index: var(--ck-z-default);
+			z-index: var(--ck-balloon-panel-arrow-z-index);
 		}
 
 		&::after {
-			z-index: calc(var(--ck-z-default) + 1);
+			z-index: calc(var(--ck-balloon-panel-arrow-z-index) + 1);
 		}
 	}
 
 	&[class*="arrow_s"] {
 		&::before {
-			z-index: var(--ck-z-default);
+			z-index: var(--ck-balloon-panel-arrow-z-index);
 		}
 
 		&::after {
-			z-index: calc(var(--ck-z-default) + 1);
+			z-index: calc(var(--ck-balloon-panel-arrow-z-index) + 1);
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Allowed list item's buttons to have an outer, visible `box-shadow`. Ensured the balloon panel's arrow does not cover panel's children. Closes #394.

---

### Additional information

**Note**: This is a piece of the constellation https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-ui/394 containing the following PRs:

* https://github.com/ckeditor/ckeditor5-theme-lark/pull/187 (the best part of the PR)
* https://github.com/ckeditor/ckeditor5-paragraph/pull/35 (icon)
* https://github.com/ckeditor/ckeditor5-heading/pull/109 (icons)
* https://github.com/ckeditor/ckeditor5-core/pull/136 (icon)

**Note**: Please build docs and check out all guides/examples when reviewing.

**Note**: Screenshots from Letters would also help /cc @dkonopka 