### PR TITLE
Used editableElement after uiReady

### DIFF
--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -59,8 +59,11 @@ export default class BalloonToolbar extends Plugin {
 		 * @type {module:utils:focustracker~FocusTracker}
 		 */
 		this.focusTracker = new FocusTracker();
-		this.focusTracker.add( this.toolbarView.element );
-		editor.once( 'uiReady', () => this.focusTracker.add( editor.ui.view.editableElement ) );
+		// Wait for the EditorUI#init. EditableElement is not available before.
+		editor.once( 'uiReady', () => {
+			this.focusTracker.add( editor.ui.view.editableElement );
+			this.focusTracker.add( this.toolbarView.element );
+		} );
 
 		/**
 		 * The contextual balloon plugin instance.

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -59,8 +59,8 @@ export default class BalloonToolbar extends Plugin {
 		 * @type {module:utils:focustracker~FocusTracker}
 		 */
 		this.focusTracker = new FocusTracker();
-		this.focusTracker.add( editor.ui.view.editableElement );
 		this.focusTracker.add( this.toolbarView.element );
+		editor.once( 'uiReady', () => this.focusTracker.add( editor.ui.view.editableElement ) );
 
 		/**
 		 * The contextual balloon plugin instance.

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -59,6 +59,7 @@ export default class BalloonToolbar extends Plugin {
 		 * @type {module:utils:focustracker~FocusTracker}
 		 */
 		this.focusTracker = new FocusTracker();
+
 		// Wait for the EditorUI#init. EditableElement is not available before.
 		editor.once( 'uiReady', () => {
 			this.focusTracker.add( editor.ui.view.editableElement );

--- a/tests/manual/tickets/418/1.js
+++ b/tests/manual/tickets/418/1.js
@@ -5,7 +5,7 @@
 
 /* globals window, document, console:false */
 
-import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
 import List from '@ckeditor/ckeditor5-list/src/list';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
@@ -19,7 +19,7 @@ import Link from '@ckeditor/ckeditor5-link/src/link';
 import BlockToolbar from '../../../../src/toolbar/block/blocktoolbar';
 import BalloonToolbar from '../../../../src/toolbar/balloon/balloontoolbar';
 
-BalloonEditor
+ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [
 			Essentials,

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -4,6 +4,7 @@
  */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import BalloonToolbar from '../../../src/toolbar/balloon/balloontoolbar';
 import ContextualBalloon from '../../../src/panel/balloon/contextualballoon';
 import BalloonPanelView from '../../../src/panel/balloon/balloonpanelview';
@@ -136,6 +137,17 @@ describe( 'BalloonToolbar', () => {
 				}, 110 );
 			}, 101 );
 		}, 100 );
+	} );
+
+	// See https://github.com/ckeditor/ckeditor5-ui/issues/424.
+	// This test should be removed after fixing this https://github.com/ckeditor/ckeditor5-core/issues/137.
+	it( 'should work with the ClassicEditor', () => {
+		const editor = new ClassicEditor( editorElement, {
+			plugins: [ BalloonToolbar ]
+		} );
+
+		// Test will fail because of rejected promise.
+		return editor.initPlugins();
 	} );
 
 	describe( 'pluginName', () => {

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -4,7 +4,6 @@
  */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import BalloonToolbar from '../../../src/toolbar/balloon/balloontoolbar';
 import ContextualBalloon from '../../../src/panel/balloon/contextualballoon';
 import BalloonPanelView from '../../../src/panel/balloon/balloonpanelview';
@@ -137,16 +136,6 @@ describe( 'BalloonToolbar', () => {
 				}, 110 );
 			}, 101 );
 		}, 100 );
-	} );
-
-	// See https://github.com/ckeditor/ckeditor5-ui/issues/424.
-	it( 'should work with the ClassicEditor', () => {
-		const editor = new ClassicEditor( editorElement, {
-			plugins: [ BalloonToolbar ]
-		} );
-
-		// Test will fail because of rejected promise.
-		return editor.initPlugins();
 	} );
 
 	describe( 'pluginName', () => {

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -140,7 +140,6 @@ describe( 'BalloonToolbar', () => {
 	} );
 
 	// See https://github.com/ckeditor/ckeditor5-ui/issues/424.
-	// This test should be removed after fixing this https://github.com/ckeditor/ckeditor5-core/issues/137.
 	it( 'should work with the ClassicEditor', () => {
 		const editor = new ClassicEditor( editorElement, {
 			plugins: [ BalloonToolbar ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Used editableElement after uiReady. Closes #424.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
