### PR TITLE
T/430: The `BalloonToolbar` should not blink when the editor receives focus

### DIFF
--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -122,6 +122,8 @@ export default class BalloonToolbar extends Plugin {
 			this._toggleVisibilityDebounced( eventName, data );
 		};
 
+		// The appearance of the BalloonToolbar method is event–driven.
+		// It is possible to stop the #show event and this prevent the toolbar from showing up.
 		this.decorate( 'show' );
 	}
 

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -253,8 +253,15 @@ export default class BalloonToolbar extends Plugin {
 		this.listenTo( this.editor.ui, 'update', () => {
 			// Don't reposition the toolbar when awaiting visibility toggle. It may cause unnecessary
 			// movement of the toolbar before it disappears.
-			if ( !this._isVisibilityTogglePending ) {
-				this._balloon.updatePosition( this._getBalloonPositionData() );
+			if ( this._isVisibilityTogglePending ) {
+				this.once( '_toggleVisibilityDebounced', () => {
+					// The toolbar could be hidden upon #_toggleVisibilityDebounced.
+					if ( this._isToolbarVisible ) {
+						this._updatePosition();
+					}
+				}, { priority: 'low' } );
+			} else {
+				this._updatePosition();
 			}
 		} );
 
@@ -274,6 +281,15 @@ export default class BalloonToolbar extends Plugin {
 			this.stopListening( this.editor.ui, 'update' );
 			this._balloon.remove( this.toolbarView );
 		}
+	}
+
+	/**
+	 * Updates the position of the toolbar.
+	 *
+	 * @private
+	 */
+	_updatePosition() {
+		this._balloon.updatePosition( this._getBalloonPositionData() );
 	}
 
 	/**

--- a/src/toolbar/balloon/balloontoolbar.js
+++ b/src/toolbar/balloon/balloontoolbar.js
@@ -121,6 +121,8 @@ export default class BalloonToolbar extends Plugin {
 
 			this._toggleVisibilityDebounced( eventName, data );
 		};
+
+		this.decorate( 'show' );
 	}
 
 	/**

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -298,18 +298,25 @@ describe( 'BalloonToolbar', () => {
 			expect( targetRect ).to.deep.equal( backwardSelectionRect );
 		} );
 
-		it( 'should update balloon position on ui#update event when #toolbarView is already added to the #_balloon', () => {
+		it( 'should update balloon position on ui#update event when #toolbarView is already added to the #_balloon', done => {
+			const spy = sandbox.spy( balloonToolbar, '_updatePosition' );
+
 			setData( model, '<paragraph>b[a]r</paragraph>' );
 
-			const spy = sandbox.spy( balloon, 'updatePosition' );
+			// Wait for any pending visibility checks.
+			balloonToolbar.once( '_toggleVisibilityDebounced', () => {
+				// Show the toolbar manually. Now, once visible, the toolbar starts
+				// positioning upon editor.ui#update.
+				balloonToolbar.show();
 
-			editor.ui.fire( 'update' );
+				editor.ui.fire( 'update' );
+				sinon.assert.calledOnce( spy );
 
-			balloonToolbar.show();
-			sinon.assert.notCalled( spy );
+				editor.ui.fire( 'update' );
+				sinon.assert.calledTwice( spy );
 
-			editor.ui.fire( 'update' );
-			sinon.assert.calledOnce( spy );
+				done();
+			} );
 		} );
 
 		it( 'should not add #toolbarView to the #_balloon more than once', () => {

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -588,6 +588,29 @@ describe( 'BalloonToolbar', () => {
 		} );
 	} );
 
+	describe( 'show event', () => {
+		it( 'should fire `show` event just before panel shows', () => {
+			const spy = sandbox.spy();
+
+			balloonToolbar.on( 'show', spy );
+			setData( model, '<paragraph>b[a]r</paragraph>' );
+
+			balloonToolbar.show();
+			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should not show the panel when `show` event is stopped', () => {
+			const balloonAddSpy = sandbox.spy( balloon, 'add' );
+
+			setData( model, '<paragraph>b[a]r</paragraph>' );
+
+			balloonToolbar.on( 'show', evt => evt.stop(), { priority: 'high' } );
+
+			balloonToolbar.show();
+			sinon.assert.notCalled( balloonAddSpy );
+		} );
+	} );
+
 	function stubSelectionRects( rects ) {
 		const originalViewRangeToDom = editingView.domConverter.viewRangeToDom;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: The `BalloonToolbar` should not blink when the editor receives focus. Closes #430.

---

### Additional information

Requires a small correction in the image tests https://github.com/ckeditor/ckeditor5-image/tree/t/ckeditor5-ui/430.
