### PR TITLE
Made the `Edit block` string translatable.

### DIFF
--- a/lang/contexts.json
+++ b/lang/contexts.json
@@ -1,4 +1,5 @@
 {
 	"Rich Text Editor, %0": "Title of the CKEditor5 editor.",
-	"Rich Text Editor": "Title of the CKEditor5 editor."
+	"Rich Text Editor": "Title of the CKEditor5 editor.",
+	"Edit block": "Label of the block toolbar icon (a block toolbar is displayed next to each paragraph, heading, list item, etc. and contains e.g. block formatting options)"
 }

--- a/src/toolbar/block/blocktoolbar.js
+++ b/src/toolbar/block/blocktoolbar.js
@@ -208,10 +208,11 @@ export default class BlockToolbar extends Plugin {
 	 */
 	_createButtonView() {
 		const editor = this.editor;
+		const t = editor.t;
 		const buttonView = new BlockButtonView( editor.locale );
 
 		buttonView.set( {
-			label: editor.t( 'Edit block' ),
+			label: t( 'Edit block' ),
 			icon: iconPilcrow,
 			withText: false
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Made the `Edit block` string translatable. Closes #445.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
