### PR TITLE
t/123: Implemented smart `DropdownView` panel positioning

### DIFF
--- a/src/dropdown/dropdownpanelview.js
+++ b/src/dropdown/dropdownpanelview.js
@@ -34,6 +34,18 @@ export default class DropdownPanelView extends View {
 		this.set( 'isVisible', false );
 
 		/**
+		 * The position of the panel, relative to the parent.
+		 *
+		 * This property is reflected in the CSS class set to {@link #element} that controls
+		 * the position of the panel.
+		 *
+		 * @observable
+		 * @default 'se'
+		 * @member {'se'|'sw'|'ne'|'nw'} #position
+		 */
+		this.set( 'position', 'se' );
+
+		/**
 		 * Collection of the child views in this panel.
 		 *
 		 * A common child type is the {@link module:ui/list/listview~ListView} and {@link module:ui/toolbar/toolbarview~ToolbarView}.
@@ -53,6 +65,7 @@ export default class DropdownPanelView extends View {
 					'ck',
 					'ck-reset',
 					'ck-dropdown__panel',
+					bind.to( 'position', value => `ck-dropdown__panel_${ value }` ),
 					bind.if( 'isVisible', 'ck-dropdown__panel-visible' )
 				]
 			},

--- a/src/dropdown/utils.js
+++ b/src/dropdown/utils.js
@@ -150,13 +150,22 @@ export function addToolbarToDropdown( dropdownView, buttons ) {
  *
  *		items.add( {
  *			type: 'button',
- *			model: new Model( { label: 'First item', labelStyle: 'color: red' } )
+ *			model: new Model( {
+ *				withText: true,
+ *				label: 'First item',
+ *				labelStyle: 'color: red'
+ *			} )
  *		} );
  *
  *		items.add( {
  *			 type: 'button',
- *			 model: new Model( { label: 'Second item', labelStyle: 'color: green', class: 'foo' } )
- * 		} );
+ *			 model: new Model( {
+ *				withText: true,
+ *				label: 'Second item',
+ *				labelStyle: 'color: green',
+ *				class: 'foo'
+ *			} )
+ *		} );
  *
  *		const dropdown = createDropdown( locale );
  *

--- a/tests/dropdown/dropdownpanelview.js
+++ b/tests/dropdown/dropdownpanelview.js
@@ -50,6 +50,14 @@ describe( 'DropdownPanelView', () => {
 					view.isVisible = false;
 					expect( view.element.classList.contains( 'ck-dropdown__panel-visible' ) ).to.be.false;
 				} );
+
+				it( 'reacts on view#position', () => {
+					expect( view.element.classList.contains( 'ck-dropdown__panel_se' ) ).to.be.true;
+
+					view.position = 'nw';
+					expect( view.element.classList.contains( 'ck-dropdown__panel_se' ) ).to.be.false;
+					expect( view.element.classList.contains( 'ck-dropdown__panel_nw' ) ).to.be.true;
+				} );
 			} );
 
 			describe( 'listeners', () => {

--- a/tests/dropdown/manual/dropdown.js
+++ b/tests/dropdown/manual/dropdown.js
@@ -45,10 +45,14 @@ function testList() {
 	const collection = new Collection( { idProperty: 'label' } );
 
 	[ '0.8em', '1em', '1.2em', '1.5em', '2.0em', '3.0em' ].forEach( font => {
-		collection.add( new Model( {
-			label: font,
-			style: `font-size: ${ font }`
-		} ) );
+		collection.add( {
+			type: 'button',
+			model: new Model( {
+				label: font,
+				labelStyle: `font-size: ${ font }`,
+				withText: true
+			} )
+		} );
 	} );
 
 	const dropdownView = createDropdown( {} );

--- a/tests/dropdown/manual/panelposition.html
+++ b/tests/dropdown/manual/panelposition.html
@@ -1,0 +1,28 @@
+<style>
+	div[id^="dropdown-"].ck {
+		position: fixed;
+	}
+
+	#dropdown-nw {
+		top: 20px;
+	}
+
+	#dropdown-ne {
+		top: 20px;
+		right: 20px;
+	}
+
+	#dropdown-sw {
+		bottom: 20px;
+	}
+
+	#dropdown-se {
+		bottom: 20px;
+		right: 20px;
+	}
+</style>
+
+<div id="dropdown-nw" class="ck ck-reset_all"></div>
+<div id="dropdown-ne" class="ck ck-reset_all"></div>
+<div id="dropdown-se" class="ck ck-reset_all"></div>
+<div id="dropdown-sw" class="ck ck-reset_all"></div>

--- a/tests/dropdown/manual/panelposition.js
+++ b/tests/dropdown/manual/panelposition.js
@@ -1,0 +1,49 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Model from '../../../src/model';
+import Collection from '@ckeditor/ckeditor5-utils/src/collection';
+import testUtils from '../../_utils/utils';
+import { createDropdown, addListToDropdown } from '../../../src/dropdown/utils';
+
+const ui = testUtils.createTestUIView( {
+	dropdownNW: '#dropdown-nw',
+	dropdownNE: '#dropdown-ne',
+	dropdownSE: '#dropdown-se',
+	dropdownSW: '#dropdown-sw'
+} );
+
+function createPositionedDropdown( position ) {
+	const collection = new Collection( { idProperty: 'label' } );
+
+	[
+		'long label of a first item of the list',
+		'long label of a second item of the list',
+		'long label of a third item of the list'
+	].forEach( label => {
+		collection.add( {
+			type: 'button',
+			model: new Model( { label, withText: true } )
+		} );
+	} );
+
+	const dropdownView = createDropdown( {} );
+
+	dropdownView.buttonView.set( {
+		label: `Dropdown ${ position }`,
+		isEnabled: true,
+		isOn: false,
+		withText: true
+	} );
+
+	addListToDropdown( dropdownView, collection );
+
+	ui[ `dropdown${ position }` ].add( dropdownView );
+}
+
+createPositionedDropdown( 'NW' );
+createPositionedDropdown( 'NE' );
+createPositionedDropdown( 'SW' );
+createPositionedDropdown( 'SE' );

--- a/tests/dropdown/manual/panelposition.md
+++ b/tests/dropdown/manual/panelposition.md
@@ -1,0 +1,5 @@
+## Automatic position of the dropdown panel
+
+1. Open a dropdown located in the corner of the page.
+2. Check if the panel shows up fully visible in the viewport.
+3. Repeat for the rest of dropdowns. Panels should appear above, below, right and left to the button.

--- a/theme/components/dropdown/dropdown.css
+++ b/theme/components/dropdown/dropdown.css
@@ -34,14 +34,32 @@
 		z-index: var(--ck-z-modal);
 
 		position: absolute;
-		left: 0px;
-		transform: translate3d( 0, 100%, 0 );
 
 		&.ck-dropdown__panel-visible {
 			display: inline-block;
 
 			/* This will prevent blurry icons in dropdown on Firefox. See #340. */
 			will-change: transform;
+		}
+
+		&.ck-dropdown__panel_ne,
+		&.ck-dropdown__panel_nw {
+			bottom: 100%;
+		}
+
+		&.ck-dropdown__panel_se,
+		&.ck-dropdown__panel_sw {
+			transform: translate3d( 0, 100%, 0 );
+		}
+
+		&.ck-dropdown__panel_ne,
+		&.ck-dropdown__panel_se {
+			left: 0px;
+		}
+
+		&.ck-dropdown__panel_nw,
+		&.ck-dropdown__panel_sw {
+			right: 0px;
 		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented configurable, smart `DropdownView` panel positioning. Closes #123.

Also fixed some dropdown–related documentation and manual tests.

---

### Additional information

I fixed some outdated docs and manual tests in this branch, which were abandoned as the API changed in the past. The UI framework guide also needed revisiting and changes are in a [separate PR in the root repository](https://github.com/ckeditor/ckeditor5/pull/1296), so it's nice if they were verified and merged too.

![image](https://user-images.githubusercontent.com/1099479/46862334-eb785600-ce14-11e8-90c0-19d805039187.png)

![image](https://user-images.githubusercontent.com/1099479/46862357-f03d0a00-ce14-11e8-8b8d-d2de9573be9d.png)
