### PR TITLE
Added `.ck-read-only` class to `EditableUIView`

### DIFF
--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -40,7 +40,7 @@ export default class EditableUIView extends View {
 					'ck-editor__editable',
 					'ck-rounded-corners',
 					bind.to( 'isFocused', value => value ? 'ck-focused' : 'ck-blurred' ),
-					bind.to( 'isReadOnly', value => value ? 'ck-read-only' : '' )
+					bind.if( 'isReadOnly', 'ck-read-only' )
 
 				],
 				contenteditable: bind.to( 'isReadOnly', value => !value ),

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -39,7 +39,9 @@ export default class EditableUIView extends View {
 					'ck-content',
 					'ck-editor__editable',
 					'ck-rounded-corners',
-					bind.to( 'isFocused', value => value ? 'ck-focused' : 'ck-blurred' )
+					bind.to( 'isFocused', value => value ? 'ck-focused' : 'ck-blurred' ),
+					bind.to( 'isReadOnly', value => value ? 'ck-read-only' : '' )
+
 				],
 				contenteditable: bind.to( 'isReadOnly', value => !value ),
 			}

--- a/tests/editableui/editableuiview.js
+++ b/tests/editableui/editableuiview.js
@@ -75,9 +75,11 @@ describe( 'EditableUIView', () => {
 			it( 'reacts on view#isReadOnly', () => {
 				view.isReadOnly = true;
 				expect( view.element.hasAttribute( 'contenteditable' ) ).to.be.false;
+				expect( view.element.classList.contains( 'ck-read-only' ) ).to.be.true;
 
 				view.isReadOnly = false;
 				expect( view.element.hasAttribute( 'contenteditable' ) ).to.be.true;
+				expect( view.element.classList.contains( 'ck-read-only' ) ).to.be.false;
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added the `.ck-read-only` CSS class to the `EditableUIView` when `view#isReadOnly` is true. 

---

### Additional information

Part of: https://github.com/ckeditor/ckeditor5-theme-lark/pull/208