### PR TITLE
T/ckeditor5/479: Moved the editable attributes management to the engine

### DIFF
--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -22,10 +22,10 @@ export default class EditableUIView extends View {
 	 * @param {HTMLElement} [editableElement] The editable element. If not specified, this view
 	 * should create it. Otherwise, the existing element should be used.
 	 */
-	constructor( locale, editableElement ) {
+	constructor( locale, editableElement, editingView ) {
 		super( locale );
 
-		const bind = this.bindTemplate;
+		this.editingView = editingView;
 
 		if ( editableElement ) {
 			this.element = this.editableElement = editableElement;
@@ -38,22 +38,10 @@ export default class EditableUIView extends View {
 					'ck',
 					'ck-content',
 					'ck-editor__editable',
-					'ck-rounded-corners',
-					bind.to( 'isFocused', value => value ? 'ck-focused' : 'ck-blurred' ),
-					bind.if( 'isReadOnly', 'ck-read-only' )
-
-				],
-				contenteditable: bind.to( 'isReadOnly', value => !value ),
+					'ck-rounded-corners'
+				]
 			}
 		} );
-
-		/**
-		 * Controls whether the editable is writable or not.
-		 *
-		 * @observable
-		 * @member {Boolean} #isReadOnly
-		 */
-		this.set( 'isReadOnly', false );
 
 		/**
 		 * Controls whether the editable is focused, i.e. the user is typing in it.
@@ -91,6 +79,19 @@ export default class EditableUIView extends View {
 		} else {
 			this.editableElement = this.element;
 		}
+	}
+
+	attachDomRootActions() {
+		const viewRoot = this.editingView.domConverter.domToView( this.element );
+		const updateFocusClasses = () => {
+			this.editingView.change( writer => {
+				writer.addClass( this.isFocused ? 'ck-focused' : 'ck-blurred', viewRoot );
+				writer.removeClass( this.isFocused ? 'ck-blurred' : 'ck-focused', viewRoot );
+			} );
+		};
+
+		this.on( 'change:isFocused', updateFocusClasses );
+		updateFocusClasses();
 	}
 
 	/**

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -59,6 +59,8 @@ export default class EditableUIView extends View {
 		 */
 		this.externalElement = editableElement;
 
+		this.viewRoot = null;
+
 		/**
 		 * The element which is the main editable element (usually the one with `contentEditable="true"`).
 		 *
@@ -81,8 +83,9 @@ export default class EditableUIView extends View {
 		}
 	}
 
-	attachDomRootActions() {
-		const viewRoot = this.editingView.domConverter.domToView( this.element );
+	enableDomRootActions() {
+		const viewRoot = this.viewRoot = this.editingView.domConverter.domToView( this.element );
+
 		const updateFocusClasses = () => {
 			this.editingView.change( writer => {
 				writer.addClass( this.isFocused ? 'ck-focused' : 'ck-blurred', viewRoot );
@@ -92,6 +95,12 @@ export default class EditableUIView extends View {
 
 		this.on( 'change:isFocused', updateFocusClasses );
 		updateFocusClasses();
+	}
+
+	disableDomRootActions() {
+		this.editingView.change( writer => {
+			writer.removeClass( [ 'ck-blurred', 'ck-focused' ], this.viewRoot );
+		} );
 	}
 
 	/**

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -97,8 +97,8 @@ export default class EditableUIView extends View {
 			this._editableElement = this.element;
 		}
 
-		this.on( 'change:isFocused', () => this._updateisFocusedClasses() );
-		this._updateisFocusedClasses();
+		this.on( 'change:isFocused', () => this._updateIsFocusedClasses() );
+		this._updateIsFocusedClasses();
 	}
 
 	/**
@@ -118,7 +118,7 @@ export default class EditableUIView extends View {
 	 *
 	 * @private
 	 */
-	_updateisFocusedClasses() {
+	_updateIsFocusedClasses() {
 		const editingView = this._editingView;
 
 		editingView.change( writer => {

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -41,10 +41,9 @@ export default class EditableUIView extends View {
 		/**
 		 * The name of the editable UI view.
 		 *
-		 * @observable
 		 * @member {String} #name
 		 */
-		this.set( 'name', null );
+		this.name = null;
 
 		/**
 		 * Controls whether the editable is focused, i.e. the user is typing in it.

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -96,6 +96,8 @@ export default class EditableUIView extends View {
 	}
 
 	disableEditingRootListeners() {
+		super.disableEditingRootListeners();
+
 		this.editingView.change( writer => {
 			writer.removeClass( [ 'ck-blurred', 'ck-focused' ], this.viewRoot );
 		} );

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -55,8 +55,6 @@ export default class EditableUIView extends View {
 		 */
 		this._editableElement = editableElement;
 
-		this.viewRoot = null;
-
 		/**
 		 * Whether an external {@link #_editableElement} was passed into the constructor, which also means
 		 * the view will not render its {@link #template}.
@@ -79,13 +77,11 @@ export default class EditableUIView extends View {
 		} else {
 			this._editableElement = this.element;
 		}
-	}
-
-	enableEditingRootListeners() {
-		const viewRoot = this.viewRoot = this.editingView.domConverter.domToView( this.element );
 
 		const updateFocusClasses = () => {
 			this.editingView.change( writer => {
+				const viewRoot = this.editingView.document.getRoot( this.name );
+
 				writer.addClass( this.isFocused ? 'ck-focused' : 'ck-blurred', viewRoot );
 				writer.removeClass( this.isFocused ? 'ck-blurred' : 'ck-focused', viewRoot );
 			} );

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -114,7 +114,7 @@ export default class EditableUIView extends View {
 
 	/**
 	 * Updates the `ck-focused` and `ck-blurred` CSS classes on the {@link #element} according to
-	 * the {@link #isFocused} property value using the {@link #editingView editing view} API.
+	 * the {@link #isFocused} property value using the {@link #_editingView editing view} API.
 	 *
 	 * @private
 	 */

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -22,7 +22,7 @@ export default class EditableUIView extends View {
 	 * @param {HTMLElement} [editableElement] The editable element. If not specified, this view
 	 * should create it. Otherwise, the existing element should be used.
 	 */
-	constructor( locale, editableElement, editingView ) {
+	constructor( locale, editingView, editableElement ) {
 		super( locale );
 
 		this.editingView = editingView;

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -95,14 +95,6 @@ export default class EditableUIView extends View {
 		updateFocusClasses();
 	}
 
-	disableEditingRootListeners() {
-		super.disableEditingRootListeners();
-
-		this.editingView.change( writer => {
-			writer.removeClass( [ 'ck-blurred', 'ck-focused' ], this.viewRoot );
-		} );
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -81,7 +81,7 @@ export default class EditableUIView extends View {
 		}
 	}
 
-	enableDomRootActions() {
+	enableEditingRootListeners() {
 		const viewRoot = this.viewRoot = this.editingView.domConverter.domToView( this.element );
 
 		const updateFocusClasses = () => {
@@ -95,7 +95,7 @@ export default class EditableUIView extends View {
 		updateFocusClasses();
 	}
 
-	disableDomRootActions() {
+	disableEditingRootListeners() {
 		this.editingView.change( writer => {
 			writer.removeClass( [ 'ck-blurred', 'ck-focused' ], this.viewRoot );
 		} );

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -59,10 +59,4 @@ export default class InlineEditableUIView extends EditableUIView {
 		this.on( 'change:name', updateAriaLabelAttribute );
 		updateAriaLabelAttribute();
 	}
-
-	disableEditingRootListeners() {
-		this.editingView.change( writer => {
-			writer.removeAttribute( 'aria-label', this.viewRoot );
-		} );
-	}
 }

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -42,8 +42,8 @@ export default class InlineEditableUIView extends EditableUIView {
 		} );
 	}
 
-	enableDomRootActions() {
-		super.enableDomRootActions();
+	enableEditingRootListeners() {
+		super.enableEditingRootListeners();
 
 		const t = this.t;
 		const updateAriaLabelAttribute = () => {
@@ -60,7 +60,7 @@ export default class InlineEditableUIView extends EditableUIView {
 		updateAriaLabelAttribute();
 	}
 
-	disableDomRootActions() {
+	disableEditingRootListeners() {
 		this.editingView.change( writer => {
 			writer.removeAttribute( 'aria-label', this.viewRoot );
 		} );

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -23,8 +23,8 @@ export default class InlineEditableUIView extends EditableUIView {
 	 * {@link module:ui/editableui/editableuiview~EditableUIView}
 	 * will create it. Otherwise, the existing element will be used.
 	 */
-	constructor( locale, editableElement, view ) {
-		super( locale, editableElement, view );
+	constructor( locale, editingView, editableElement ) {
+		super( locale, editingView, editableElement );
 
 		/**
 		 * The name of the editable UI view.

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -19,20 +19,13 @@ export default class InlineEditableUIView extends EditableUIView {
 	 * Creates an instance of the InlineEditableUIView class.
 	 *
 	 * @param {module:utils/locale~Locale} [locale] The locale instance.
+	 * @param {module:engine/view/view~View} editingView The editing view instance the editable is related to.
 	 * @param {HTMLElement} [editableElement] The editable element. If not specified, the
 	 * {@link module:ui/editableui/editableuiview~EditableUIView}
 	 * will create it. Otherwise, the existing element will be used.
 	 */
 	constructor( locale, editingView, editableElement ) {
 		super( locale, editingView, editableElement );
-
-		/**
-		 * The name of the editable UI view.
-		 *
-		 * @observable
-		 * @member {String} #name
-		 */
-		this.set( 'name', null );
 
 		this.extendTemplate( {
 			attributes: {
@@ -42,23 +35,19 @@ export default class InlineEditableUIView extends EditableUIView {
 		} );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	render() {
 		super.render();
 
+		const editingView = this._editingView;
 		const t = this.t;
-		const updateAriaLabelAttribute = () => {
-			this.editingView.change( writer => {
-				const viewRoot = this.editingView.document.getRoot( this.name );
 
-				if ( this.name ) {
-					writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), viewRoot );
-				} else {
-					writer.removeAttribute( 'aria-label', viewRoot );
-				}
-			} );
-		};
+		editingView.change( writer => {
+			const viewRoot = editingView.document.getRoot( this.name );
 
-		this.on( 'change:name', updateAriaLabelAttribute );
-		updateAriaLabelAttribute();
+			writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), viewRoot );
+		} );
 	}
 }

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -23,11 +23,8 @@ export default class InlineEditableUIView extends EditableUIView {
 	 * {@link module:ui/editableui/editableuiview~EditableUIView}
 	 * will create it. Otherwise, the existing element will be used.
 	 */
-	constructor( locale, editableElement ) {
-		super( locale, editableElement );
-
-		const bind = this.bindTemplate;
-		const t = this.t;
+	constructor( locale, editableElement, view ) {
+		super( locale, editableElement, view );
 
 		/**
 		 * The name of the editable UI view.
@@ -37,16 +34,30 @@ export default class InlineEditableUIView extends EditableUIView {
 		 */
 		this.set( 'name', null );
 
-		const getLabel = value => {
-			return t( 'Rich Text Editor, %0', [ value ] );
-		};
-
 		this.extendTemplate( {
 			attributes: {
 				role: 'textbox',
-				'aria-label': bind.to( 'name', getLabel ),
 				class: 'ck-editor__editable_inline'
 			}
 		} );
+	}
+
+	attachDomRootActions() {
+		super.attachDomRootActions();
+
+		const t = this.t;
+		const viewRoot = this.editingView.domConverter.domToView( this.element );
+		const updateAriaLabelAttribute = () => {
+			this.editingView.change( writer => {
+				if ( this.name ) {
+					writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), viewRoot );
+				} else {
+					writer.removeAttribute( 'aria-label', viewRoot );
+				}
+			} );
+		};
+
+		this.on( 'change:name', updateAriaLabelAttribute );
+		updateAriaLabelAttribute();
 	}
 }

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -42,16 +42,18 @@ export default class InlineEditableUIView extends EditableUIView {
 		} );
 	}
 
-	enableEditingRootListeners() {
-		super.enableEditingRootListeners();
+	render() {
+		super.render();
 
 		const t = this.t;
 		const updateAriaLabelAttribute = () => {
 			this.editingView.change( writer => {
+				const viewRoot = this.editingView.document.getRoot( this.name );
+
 				if ( this.name ) {
-					writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), this.viewRoot );
+					writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), viewRoot );
 				} else {
-					writer.removeAttribute( 'aria-label', this.viewRoot );
+					writer.removeAttribute( 'aria-label', viewRoot );
 				}
 			} );
 		};

--- a/src/editableui/inline/inlineeditableuiview.js
+++ b/src/editableui/inline/inlineeditableuiview.js
@@ -42,22 +42,27 @@ export default class InlineEditableUIView extends EditableUIView {
 		} );
 	}
 
-	attachDomRootActions() {
-		super.attachDomRootActions();
+	enableDomRootActions() {
+		super.enableDomRootActions();
 
 		const t = this.t;
-		const viewRoot = this.editingView.domConverter.domToView( this.element );
 		const updateAriaLabelAttribute = () => {
 			this.editingView.change( writer => {
 				if ( this.name ) {
-					writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), viewRoot );
+					writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), this.viewRoot );
 				} else {
-					writer.removeAttribute( 'aria-label', viewRoot );
+					writer.removeAttribute( 'aria-label', this.viewRoot );
 				}
 			} );
 		};
 
 		this.on( 'change:name', updateAriaLabelAttribute );
 		updateAriaLabelAttribute();
+	}
+
+	disableDomRootActions() {
+		this.editingView.change( writer => {
+			writer.removeAttribute( 'aria-label', this.viewRoot );
+		} );
 	}
 }

--- a/tests/editableui/inline/inlineeditableuiview.js
+++ b/tests/editableui/inline/inlineeditableuiview.js
@@ -5,17 +5,25 @@
 
 /* globals document */
 
+import EditingView from '@ckeditor/ckeditor5-engine/src/view/view';
+import ViewRootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditableelement';
 import InlineEditableUIView from '../../../src/editableui/inline/inlineeditableuiview';
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
 
 describe( 'InlineEditableUIView', () => {
-	let view, editableElement, locale;
+	let view, editableElement, editingView, editingViewRoot, locale;
 
 	beforeEach( () => {
 		locale = new Locale( 'en' );
 		editableElement = document.createElement( 'div' );
 
-		view = new InlineEditableUIView( locale );
+		editingView = new EditingView();
+		editingViewRoot = new ViewRootEditableElement( 'div' );
+		editingViewRoot._document = editingView.document;
+		editingView.document.roots.add( editingViewRoot );
+		view = new InlineEditableUIView( locale, editingView );
+		view.name = editingViewRoot.rootName;
+
 		view.render();
 	} );
 
@@ -24,12 +32,8 @@ describe( 'InlineEditableUIView', () => {
 			expect( view.locale ).to.equal( locale );
 		} );
 
-		it( 'sets initial values of attributes', () => {
-			expect( view.name ).to.be.null;
-		} );
-
 		it( 'accepts editableElement', () => {
-			view = new InlineEditableUIView( locale, editableElement );
+			view = new InlineEditableUIView( locale, editingView, editableElement );
 
 			expect( view._editableElement ).to.equal( editableElement );
 		} );
@@ -40,18 +44,14 @@ describe( 'InlineEditableUIView', () => {
 	} );
 
 	describe( 'editableElement', () => {
-		const ariaLabel = 'Rich Text Editor, foo';
-
-		beforeEach( () => {
-			view.name = 'foo';
-		} );
+		const ariaLabel = 'Rich Text Editor, main';
 
 		it( 'has proper accessibility role', () => {
 			expect( view.element.attributes.getNamedItem( 'role' ).value ).to.equal( 'textbox' );
 		} );
 
 		it( 'has proper ARIA label', () => {
-			expect( view.element.getAttribute( 'aria-label' ) ).to.equal( ariaLabel );
+			expect( editingViewRoot.getAttribute( 'aria-label' ) ).to.equal( ariaLabel );
 		} );
 
 		it( 'has proper class name', () => {

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -230,7 +230,7 @@ describe( 'BalloonToolbar', () => {
 
 			const targetViewRange = editingView.domConverter.viewRangeToDom.lastCall.args[ 0 ];
 
-			expect( viewStringify( targetViewRange.root, targetViewRange ) ).to.equal( '<div><p>bar</p><p>{bi}z</p></div>' );
+			expect( viewStringify( targetViewRange.root, targetViewRange, { ignoreRoot: true } ) ).to.equal( '<p>bar</p><p>{bi}z</p>' );
 			expect( targetRect ).to.deep.equal( forwardSelectionRect );
 		} );
 
@@ -289,7 +289,7 @@ describe( 'BalloonToolbar', () => {
 
 			const targetViewRange = editingView.domConverter.viewRangeToDom.lastCall.args[ 0 ];
 
-			expect( viewStringify( targetViewRange.root, targetViewRange ) ).to.equal( '<div><p>b{ar}</p><p>biz</p></div>' );
+			expect( viewStringify( targetViewRange.root, targetViewRange, { ignoreRoot: true } ) ).to.equal( '<p>b{ar}</p><p>biz</p>' );
 			expect( targetRect ).to.deep.equal( backwardSelectionRect );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Moved the `EditableUIView` and  `InlineEditableUIView` attributes management to the engine (see ckeditor/ckeditor5#479). Closes ckeditor/ckeditor5#798.

BREAKING CHANGE: The `EditableUIView#isReadOnly` property has been removed. Use the engine `EditableElement#isReadOnly` instead.

BREAKING CHANGE: The second argument of `EditableUIView.constructor()` and `InlineEditableUIView.constructor()` became the instance of the editing view (previously an optional editable element reference).

---

### Additional information

Part of the [constellation](https://github.com/ckeditor/ckeditor5/tree/t/479).