### PR TITLE
Tests: Remove all usages of `view.editableElement`

### DIFF
--- a/tests/manual/tickets/170/1.js
+++ b/tests/manual/tickets/170/1.js
@@ -28,7 +28,7 @@ ClassicEditor
 
 		panel.attachTo( {
 			target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
-			limiter: editor.ui.view.editableElement
+			limiter: editor.ui.getEditableElement()
 		} );
 
 		window.attachEditor = editor;
@@ -53,7 +53,7 @@ ClassicEditor
 
 		panel.pin( {
 			target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
-			limiter: editor.ui.view.editableElement
+			limiter: editor.ui.getEditableElement()
 		} );
 
 		window.stickEditor = editor;

--- a/tests/toolbar/balloon/balloontoolbar.js
+++ b/tests/toolbar/balloon/balloontoolbar.js
@@ -147,7 +147,7 @@ describe( 'BalloonToolbar', () => {
 		it( 'it should track the focus of the #editableElement', () => {
 			expect( balloonToolbar.focusTracker.isFocused ).to.false;
 
-			editor.ui.view.editableElement.dispatchEvent( new Event( 'focus' ) );
+			editor.ui.getEditableElement().dispatchEvent( new Event( 'focus' ) );
 
 			expect( balloonToolbar.focusTracker.isFocused ).to.true;
 		} );

--- a/tests/toolbar/block/blocktoolbar.js
+++ b/tests/toolbar/block/blocktoolbar.js
@@ -179,7 +179,7 @@ describe( 'BlockToolbar', () => {
 				expect( blockToolbar.panelView.isVisible ).to.be.true;
 				sinon.assert.calledWith( pinSpy, {
 					target: blockToolbar.buttonView.element,
-					limiter: editor.ui.view.editableElement
+					limiter: editor.ui.getEditableElement()
 				} );
 				sinon.assert.calledOnce( focusSpy );
 			} );
@@ -279,7 +279,7 @@ describe( 'BlockToolbar', () => {
 			'of the selected block #1', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
-			const target = editor.ui.view.editableElement.querySelector( 'p' );
+			const target = editor.ui.getEditableElement().querySelector( 'p' );
 			const styleMock = testUtils.sinon.stub( window, 'getComputedStyle' );
 
 			styleMock.withArgs( target ).returns( {
@@ -289,7 +289,7 @@ describe( 'BlockToolbar', () => {
 
 			styleMock.callThrough();
 
-			testUtils.sinon.stub( editor.ui.view.editableElement, 'getBoundingClientRect' ).returns( {
+			testUtils.sinon.stub( editor.ui.getEditableElement(), 'getBoundingClientRect' ).returns( {
 				left: 200
 			} );
 
@@ -313,7 +313,7 @@ describe( 'BlockToolbar', () => {
 			'of the selected block #2', () => {
 			setData( editor.model, '<paragraph>foo[]bar</paragraph>' );
 
-			const target = editor.ui.view.editableElement.querySelector( 'p' );
+			const target = editor.ui.getEditableElement().querySelector( 'p' );
 			const styleMock = testUtils.sinon.stub( window, 'getComputedStyle' );
 
 			styleMock.withArgs( target ).returns( {
@@ -324,7 +324,7 @@ describe( 'BlockToolbar', () => {
 
 			styleMock.callThrough();
 
-			testUtils.sinon.stub( editor.ui.view.editableElement, 'getBoundingClientRect' ).returns( {
+			testUtils.sinon.stub( editor.ui.getEditableElement(), 'getBoundingClientRect' ).returns( {
 				left: 200
 			} );
 
@@ -359,7 +359,7 @@ describe( 'BlockToolbar', () => {
 
 			sinon.assert.calledWith( spy, {
 				target: blockToolbar.buttonView.element,
-				limiter: editor.ui.view.editableElement
+				limiter: editor.ui.getEditableElement()
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Remove all usages of `view.editableElement`.

---

### Additional information

Reporting ticket is https://github.com/ckeditor/ckeditor5/issues/1489.
