### PR TITLE
Using the `.ck-read-only` class instead contenteditable CSS Selector.

### DIFF
--- a/docs/_snippets/examples/bootstrap-ui-inner.html
+++ b/docs/_snippets/examples/bootstrap-ui-inner.html
@@ -71,7 +71,7 @@
 			}
 
 			/* When in read–only mode, the editable should fade out. */
-			.ck-editor .ck-editor__editable:not([contenteditable]) {
+			.ck-editor .ck-editor__editable.ck-read-only {
 				background: #fafafa;
 				color: hsl(0, 0%, 47%);
 			}

--- a/docs/framework/guides/external-ui.md
+++ b/docs/framework/guides/external-ui.md
@@ -187,7 +187,7 @@ Although Bootstrap provides most of the CSS, it does not come with styles dedica
 }
 
 /* When in read–only mode, the editable should fade out. */
-.ck-editor .ck-editor__editable:not([contenteditable]) {
+.ck-editor .ck-editor__editable.ck-read-only {
 	background: hsl(0, 0%, 98%);
 	color: hsl(0, 0%, 47%);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used the `.ck-read-only` class instead `[contenteditable]` CSS Selector. Closes https://github.com/ckeditor/ckeditor5/issues/1343).

