### PR TITLE
Prevented from changing view document during the render phase.

### DIFF
--- a/src/editableui/editableuiview.js
+++ b/src/editableui/editableuiview.js
@@ -121,11 +121,19 @@ export default class EditableUIView extends View {
 	_updateIsFocusedClasses() {
 		const editingView = this._editingView;
 
-		editingView.change( writer => {
-			const viewRoot = editingView.document.getRoot( this.name );
+		if ( editingView.isRenderingInProgress ) {
+			editingView.once( 'change:isRenderingInProgress', () => update( this ) );
+		} else {
+			update( this );
+		}
 
-			writer.addClass( this.isFocused ? 'ck-focused' : 'ck-blurred', viewRoot );
-			writer.removeClass( this.isFocused ? 'ck-blurred' : 'ck-focused', viewRoot );
-		} );
+		function update( view ) {
+			editingView.change( writer => {
+				const viewRoot = editingView.document.getRoot( view.name );
+
+				writer.addClass( view.isFocused ? 'ck-focused' : 'ck-blurred', viewRoot );
+				writer.removeClass( view.isFocused ? 'ck-blurred' : 'ck-focused', viewRoot );
+			} );
+		}
 	}
 }

--- a/tests/editableui/editableuiview.js
+++ b/tests/editableui/editableuiview.js
@@ -78,6 +78,25 @@ describe( 'EditableUIView', () => {
 				expect( editingViewRoot.hasClass( 'ck-focused' ) ).to.be.false;
 				expect( editingViewRoot.hasClass( 'ck-blurred' ) ).to.be.true;
 			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/1530.
+			it( 'should work when update is handled during the rendering phase', () => {
+				view.isFocused = true;
+				editingView.isRenderingInProgress = true;
+
+				expect( editingViewRoot.hasClass( 'ck-focused' ) ).to.be.true;
+				expect( editingViewRoot.hasClass( 'ck-blurred' ) ).to.be.false;
+
+				view.isFocused = false;
+
+				expect( editingViewRoot.hasClass( 'ck-focused' ) ).to.be.true;
+				expect( editingViewRoot.hasClass( 'ck-blurred' ) ).to.be.false;
+
+				editingView.isRenderingInProgress = false;
+
+				expect( editingViewRoot.hasClass( 'ck-focused' ) ).to.be.false;
+				expect( editingViewRoot.hasClass( 'ck-blurred' ) ).to.be.true;
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevented from changing the view document during the render phase. Closes https://github.com/ckeditor/ckeditor5/issues/1530.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-engine/pull/1682.
