### PR TITLE
Add withArrow option to ContextualBalloon#add() method.

### DIFF
--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -115,7 +115,7 @@ export default class ContextualBalloon extends Plugin {
 	 * @param {module:ui/view~View} [data.view] Content of the balloon.
 	 * @param {module:utils/dom/position~Options} [data.position] Positioning options.
 	 * @param {String} [data.balloonClassName] Additional css class for {@link #view} added when given view is visible.
-	 * @param {Boolean} [data.withArrow=true] Whether the {#_balloon} view should be rendered with arrow.
+	 * @param {Boolean} [data.withArrow=true] Whether the balloon should be rendered with an arrow.
 	 */
 	add( data ) {
 		if ( this.hasView( data.view ) ) {

--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -204,7 +204,7 @@ export default class ContextualBalloon extends Plugin {
 	 * @param {Object} data Configuration.
 	 * @param {module:ui/view~View} [data.view] View to show in the balloon.
 	 * @param {String} [data.balloonClassName=''] Additional class name which will added to the {#_balloon} view.
-	 * @param {Boolean} [data.withArrow=true] Whether the {#_balloon} view should be rendered with arrow.
+	 * @param {Boolean} [data.withArrow=true] Whether the {@link #_balloon} view should be rendered with an arrow.
 	 */
 	_show( { view, balloonClassName = '', withArrow = true } ) {
 		this.view.class = balloonClassName;

--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -115,6 +115,7 @@ export default class ContextualBalloon extends Plugin {
 	 * @param {module:ui/view~View} [data.view] Content of the balloon.
 	 * @param {module:utils/dom/position~Options} [data.position] Positioning options.
 	 * @param {String} [data.balloonClassName] Additional css class for {@link #view} added when given view is visible.
+	 * @param {Boolean} [data.withArrow=true] Whether the {#_balloon} view should be rendered with arrow.
 	 */
 	add( data ) {
 		if ( this.hasView( data.view ) ) {
@@ -203,9 +204,11 @@ export default class ContextualBalloon extends Plugin {
 	 * @param {Object} data Configuration.
 	 * @param {module:ui/view~View} [data.view] View to show in the balloon.
 	 * @param {String} [data.balloonClassName=''] Additional class name which will added to the {#_balloon} view.
+	 * @param {Boolean} [data.withArrow=true] Whether the {#_balloon} view should be rendered with arrow.
 	 */
-	_show( { view, balloonClassName = '' } ) {
+	_show( { view, balloonClassName = '', withArrow = true } ) {
 		this.view.class = balloonClassName;
+		this.view.withArrow = withArrow;
 
 		this.view.content.add( view );
 		this.view.pin( this._getBalloonPosition() );

--- a/tests/panel/balloon/contextualballoon.js
+++ b/tests/panel/balloon/contextualballoon.js
@@ -299,6 +299,47 @@ describe( 'ContextualBalloon', () => {
 
 			expect( balloon.view.class ).to.equal( 'bar' );
 		} );
+
+		it( 'should hide arrow if `withArrow` option is set to false', () => {
+			balloon.remove( viewA );
+			balloon.view.pin.resetHistory();
+
+			balloon.add( {
+				view: viewB,
+				position: {
+					target: 'foo'
+				},
+				withArrow: false
+			} );
+
+			expect( balloon.view.withArrow ).to.be.false;
+		} );
+
+		it( 'should show arrow if `withArrow` option was not set and previously shown view had hidden arrow', () => {
+			balloon.remove( viewA );
+			balloon.view.pin.resetHistory();
+
+			balloon.add( {
+				view: viewB,
+				position: {
+					target: 'foo'
+				},
+				withArrow: false
+			} );
+
+			expect( balloon.view.withArrow ).to.be.false;
+
+			balloon.remove( viewB );
+
+			balloon.add( {
+				view: viewB,
+				position: {
+					target: 'foo'
+				}
+			} );
+
+			expect( balloon.view.withArrow ).to.be.true;
+		} );
 	} );
 
 	describe( 'visibleView', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `ContextualBalloon` plugin's `add` method now accepts the `withArrow` option. Closes #487.

---

### Additional information

I've assumed that:
* The `withArrow` name should be the same as `BalloonPanelView` property.
* The default value is `true` for backwards compatibilty.

The PR is required for: https://github.com/ckeditor/ckeditor5-mention/pull/60 (to show/hide the arrow).
