### PR TITLE
Rotatable balloons should center toolbar items

### DIFF
--- a/theme/components/panel/balloonrotator.css
+++ b/theme/components/panel/balloonrotator.css
@@ -9,7 +9,9 @@
 	justify-content: center;
 }
 
-/* Buttons inside a toolbar should be centered while rotator bar is wider (in one or two icons case). */
+/* Buttons inside a toolbar should be centered when rotator bar is wider.
+ * See: https://github.com/ckeditor/ckeditor5-ui/issues/495
+ */
 .ck .ck-balloon-rotator__content .ck-toolbar {
 	justify-content: center;
 }

--- a/theme/components/panel/balloonrotator.css
+++ b/theme/components/panel/balloonrotator.css
@@ -8,3 +8,8 @@
 	align-items: center;
 	justify-content: center;
 }
+
+/* Buttons inside a toolbar should be centered while rotator bar is wider (in one or two icons case). */
+.ck .ck-balloon-rotator__content .ck-toolbar {
+	justify-content: center;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Rotatable balloons should center toolbar items. Closes #495.

---

### Additional information

![Screen Shot 2019-05-14 at 14 28 52](https://user-images.githubusercontent.com/10219857/57697924-9de6f480-7654-11e9-9210-96a1883a7291.png)

![Screen Shot 2019-05-14 at 14 32 27](https://user-images.githubusercontent.com/10219857/57698120-206fb400-7655-11e9-958b-e17c7b142096.png)
