### PR TITLE
API docs corrections for the Notification#showWarning() method

### DIFF
--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -107,7 +107,7 @@ export default class Notification extends Plugin {
 	 * Shows a warning notification.
 	 *
 	 * By default, it fires the {@link #show:warning `show:warning`} event with the given `data`. The event namespace can be extended
-	 * using `data.namespace` option e.g.
+	 * using the `data.namespace` option. For example:
 	 *
 	 * 		showWarning( 'Image upload error.', {
 	 * 			namespace: 'upload:image'

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -115,7 +115,7 @@ export default class Notification extends Plugin {
 	 *
 	 * will fire the `show:warning:upload:image` event.
 	 *
-	 * The title of the notification can be provided:
+	 * You can provide the title of the notification:
 	 *
 	 *		showWarning( 'Image upload error.', {
 	 *			title: 'Upload failed'

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -106,7 +106,7 @@ export default class Notification extends Plugin {
 	/**
 	 * Shows a warning notification.
 	 *
-	 * By default it fires the {@link #show:warning `show:warning`} event with a given `data` but event namespace can be extended
+	 * By default, it fires the {@link #show:warning `show:warning`} event with the given `data`. The event namespace can be extended
 	 * using `data.namespace` option e.g.
 	 *
 	 * 		showWarning( 'Image upload error.', {

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -125,7 +125,7 @@ export default class Notification extends Plugin {
 	 * The plugin responsible for displaying warnings should `stop()` the event to prevent displaying it as an alert:
 	 *
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {
-	 * 			// Do something with data.
+	 * 			// Do something with the data.
 	 *
 	 * 			// Stop this event to prevent displaying it as an alert.
 	 * 			evt.stop();

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -131,10 +131,10 @@ export default class Notification extends Plugin {
 	 * 			evt.stop();
 	 * 		} );
 	 *
-	 * You can attach many listeners to the same event and `stop()` this event in the listener with the low priority:
+	 * You can attach many listeners to the same event and `stop()` this event in a listener with a low priority:
 	 *
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {
-	 * 			// Show warning in the UI, but not stop it.
+	 * 			// Show the warning in the UI, but do not stop it.
 	 * 		} );
 	 *
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -138,7 +138,7 @@ export default class Notification extends Plugin {
 	 * 		} );
 	 *
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {
-	 * 			// Log warning to some error tracker.
+	 * 			// Log the warning to some error tracker.
 	 *
 	 * 			// Stop this event to prevent displaying it as an alert.
 	 * 			evt.stop();

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -122,7 +122,7 @@ export default class Notification extends Plugin {
 	 *		} );
 	 *
 	 * Note that each unhandled and not stopped `warning` notification will be displayed as a system alert.
-	 * Plugin responsible for displaying warnings should `stop()` the event to prevent displaying it as an alert:
+	 * The plugin responsible for displaying warnings should `stop()` the event to prevent displaying it as an alert:
 	 *
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {
 	 * 			// Do something with data.

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -104,29 +104,30 @@ export default class Notification extends Plugin {
 	}
 
 	/**
-	 * Shows warning notification.
+	 * Shows a warning notification.
 	 *
-	 * At default it fires `show:warning` event with given data but event namespace can be extended
-	 * by `data.namespace` option e.g.
+	 * By default it fires the {@link #show:warning `show:warning`} event with a given `data` but event namespace can be extended
+	 * using `data.namespace` option e.g.
 	 *
 	 * 		showWarning( 'Image upload error.', {
 	 * 			namespace: 'upload:image'
 	 * 		} );
 	 *
 	 * will fire `show:warning:upload:image` event.
-	 * Title of the notification can be provided:
+	 *
+	 * The title of the notification can be provided:
 	 *
 	 *		showWarning( 'Image upload error.', {
 	 *			title: 'Upload failed'
-	 *		});
+	 *		} );
 	 *
-	 * Note that each unhandled and not stopped `warning` notification will be displayed as system alert.
-	 * Plugin responsible for displaying warnings should `stop()` the event to prevent of displaying it as alert:
+	 * Note that each unhandled and not stopped `warning` notification will be displayed as a system alert.
+	 * Plugin responsible for displaying warnings should `stop()` the event to prevent displaying it as an alert:
 	 *
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {
 	 * 			// Do something with data.
 	 *
-	 * 			// Stop this event to prevent of displaying as alert.
+	 * 			// Stop this event to prevent displaying it as an alert.
 	 * 			evt.stop();
 	 * 		} );
 	 *
@@ -139,7 +140,7 @@ export default class Notification extends Plugin {
 	 * 		notifications.on( 'show:warning', ( evt, data ) => {
 	 * 			// Log warning to some error tracker.
 	 *
-	 * 			// Stop this event to prevent of displaying as alert.
+	 * 			// Stop this event to prevent displaying it as an alert.
 	 * 			evt.stop();
 	 * 		}, { priority: 'low' } );
 	 *

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -113,7 +113,7 @@ export default class Notification extends Plugin {
 	 * 			namespace: 'upload:image'
 	 * 		} );
 	 *
-	 * will fire `show:warning:upload:image` event.
+	 * will fire the `show:warning:upload:image` event.
 	 *
 	 * The title of the notification can be provided:
 	 *

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -106,8 +106,8 @@ export default class Notification extends Plugin {
 	/**
 	 * Shows a warning notification.
 	 *
-	 * By default, it fires the {@link #show:warning `show:warning`} event with the given `data`. The event namespace can be extended
-	 * using the `data.namespace` option. For example:
+	 * By default, it fires the {@link module:ui/notification/notification~Notification#event:show:warning `show:warning` event}
+	 * with the given `data`. The event namespace can be extended using the `data.namespace` option. For example:
 	 *
 	 * 		showWarning( 'Image upload error.', {
 	 * 			namespace: 'upload:image'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Lang corrections for API docs of the `Notification#showWarning()` method.

---

### Additional information

It _partially_ addresses ckeditor/ckeditor5#1773.