### PR TITLE
t/ckeditor5/1838: Docs: Used the new `EditorUI#setEditableElement()` API in the custom editor guides

### DIFF
--- a/docs/_snippets/examples/bootstrap-ui-inner.js
+++ b/docs/_snippets/examples/bootstrap-ui-inner.js
@@ -151,7 +151,7 @@ class BootstrapEditorUI extends EditorUI {
 		const editableElement = view.editable.element;
 
 		// Register editable element so it is available via getEditableElement() method.
-		this._editableElements.set( view.editable.name, editableElement );
+		this.setEditableElement( view.editable.name, editableElement );
 
 		// Let the editable UI element respond to the changes in the global editor focus tracker
 		// and let the focus tracker know about the editable element.

--- a/docs/framework/guides/external-ui.md
+++ b/docs/framework/guides/external-ui.md
@@ -286,7 +286,7 @@ class BootstrapEditorUI extends EditorUI {
 		const editableElement = view.editable.element;
 
 		// Register editable element so it is available via getEditableElement() method.
-		this._editableElements.set( view.editable.name, editableElement );
+		this.setEditableElement( view.editable.name, editableElement );
 
 		// Let the editable UI element respond to the changes in the global editor focus tracker
 		// and let the focus tracker know about the editable element.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Used the new `EditorUI#setEditableElement()` API in the custom editor guides (see ckeditor/ckeditor5#1838).

---

### Additional information

A piece of https://github.com/ckeditor/ckeditor5/pull/1840.
