### PR TITLE
Improve the functionality of `aria-pressed` attribute in button elements

### DIFF
--- a/src/button/button.jsdoc
+++ b/src/button/button.jsdoc
@@ -96,7 +96,7 @@
  */
 
 /**
- * Controls whether the button view is recognized as toggle button for assistive technologies.
+ * Controls whether the button view is a toggle button (two–state) for assistive technologies.
  *
  * @observable
  * @default false

--- a/src/button/button.jsdoc
+++ b/src/button/button.jsdoc
@@ -96,6 +96,14 @@
  */
 
 /**
+ * Controls whether the button view is recognized as toggle button for assistive technologies.
+ *
+ * @observable
+ * @default false
+ * @member {Boolean} #isToggleable
+ */
+
+/**
  * (Optional) Controls whether the label of the button is hidden (e.g. an icon–only button).
  *
  * @observable

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -37,13 +37,7 @@ import '../../theme/components/button/button.css';
  */
 export default class ButtonView extends View {
 	/**
-	 * Creates an instance of the {@link module:ui/view~View} class.
-	 *
-	 * Also see {@link #render}.
-	 *
-	 * @param {module:utils/locale~Locale} [locale] The localization services instance.
-	 * @param {Object} [config] additional configuration
-	 * @param {Boolean} [config.toggle=false] set button as a toggle
+	 * @inheritDoc
 	 */
 	constructor( locale ) {
 		super( locale );

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -37,9 +37,15 @@ import '../../theme/components/button/button.css';
  */
 export default class ButtonView extends View {
 	/**
-	 * @inheritDoc
+	 * Creates an instance of the {@link module:ui/view~View} class.
+	 *
+	 * Also see {@link #render}.
+	 *
+	 * @param {module:utils/locale~Locale} [locale] The localization services instance.
+	 * @param {Object} [config] additional configuration
+	 * @param {Boolean} [config.toggle=false] set button as a toggle
 	 */
-	constructor( locale ) {
+	constructor( locale, { toggle = false } = {} ) {
 		super( locale );
 
 		const bind = this.bindTemplate;
@@ -131,8 +137,7 @@ export default class ButtonView extends View {
 				type: bind.to( 'type', value => value ? value : 'button' ),
 				tabindex: bind.to( 'tabindex' ),
 				'aria-labelledby': `ck-editor__aria-label_${ ariaLabelUid }`,
-				'aria-disabled': bind.if( 'isEnabled', true, value => !value ),
-				'aria-pressed': bind.to( 'isOn', value => value ? 'true' : 'false' )
+				'aria-disabled': bind.if( 'isEnabled', true, value => !value )
 			},
 
 			children: this.children,
@@ -155,6 +160,14 @@ export default class ButtonView extends View {
 				} )
 			}
 		} );
+
+		if ( toggle ) {
+			this.extendTemplate( {
+				attributes: {
+					'aria-pressed': bind.to( 'isOn', value => value ? 'true' : 'false' )
+				}
+			} );
+		}
 	}
 
 	/**

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -45,7 +45,7 @@ export default class ButtonView extends View {
 	 * @param {Object} [config] additional configuration
 	 * @param {Boolean} [config.toggle=false] set button as a toggle
 	 */
-	constructor( locale, { toggle = false } = {} ) {
+	constructor( locale ) {
 		super( locale );
 
 		const bind = this.bindTemplate;
@@ -58,6 +58,7 @@ export default class ButtonView extends View {
 		this.set( 'isEnabled', true );
 		this.set( 'isOn', false );
 		this.set( 'isVisible', true );
+		this.set( 'isToggleable', false );
 		this.set( 'keystroke' );
 		this.set( 'label' );
 		this.set( 'tabindex', -1 );
@@ -137,7 +138,8 @@ export default class ButtonView extends View {
 				type: bind.to( 'type', value => value ? value : 'button' ),
 				tabindex: bind.to( 'tabindex' ),
 				'aria-labelledby': `ck-editor__aria-label_${ ariaLabelUid }`,
-				'aria-disabled': bind.if( 'isEnabled', true, value => !value )
+				'aria-disabled': bind.if( 'isEnabled', true, value => !value ),
+				'aria-pressed': bind.to( 'isOn', value => this.isToggleable ? String( value ) : false )
 			},
 
 			children: this.children,
@@ -160,14 +162,6 @@ export default class ButtonView extends View {
 				} )
 			}
 		} );
-
-		if ( toggle ) {
-			this.extendTemplate( {
-				attributes: {
-					'aria-pressed': bind.to( 'isOn', value => value ? 'true' : 'false' )
-				}
-			} );
-		}
 	}
 
 	/**

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -132,7 +132,7 @@ export default class ButtonView extends View {
 				tabindex: bind.to( 'tabindex' ),
 				'aria-labelledby': `ck-editor__aria-label_${ ariaLabelUid }`,
 				'aria-disabled': bind.if( 'isEnabled', true, value => !value ),
-				'aria-pressed': bind.if( 'isOn', true )
+				'aria-pressed': bind.to( 'isOn', value => value ? 'true' : 'false' )
 			},
 
 			children: this.children,

--- a/src/button/switchbuttonview.js
+++ b/src/button/switchbuttonview.js
@@ -35,6 +35,8 @@ export default class SwitchButtonView extends ButtonView {
 	constructor( locale ) {
 		super( locale );
 
+		this.isToggleable = true;
+
 		/**
 		 * The toggle switch of the button.
 		 *
@@ -42,15 +44,6 @@ export default class SwitchButtonView extends ButtonView {
 		 * @member {module:ui/view~View} #toggleSwitchView
 		 */
 		this.toggleSwitchView = this._createToggleView();
-
-		/**
-		 * Controls whether the button view is recognized as toggle button for assistive technologies.
-		 *
-		 * @observable
-		 * @default true
-		 * @member {Boolean} #isToggleable
-		 */
-		this.isToggleable = true;
 
 		this.extendTemplate( {
 			attributes: {

--- a/src/button/switchbuttonview.js
+++ b/src/button/switchbuttonview.js
@@ -43,6 +43,15 @@ export default class SwitchButtonView extends ButtonView {
 		 */
 		this.toggleSwitchView = this._createToggleView();
 
+		/**
+		 * Controls whether the button view is recognized as toggle button for assistive technologies.
+		 *
+		 * @observable
+		 * @default true
+		 * @member {Boolean} #isToggleable
+		 */
+		this.isToggleable = true;
+
 		this.extendTemplate( {
 			attributes: {
 				class: 'ck-switchbutton'

--- a/src/dropdown/button/splitbuttonview.js
+++ b/src/dropdown/button/splitbuttonview.js
@@ -204,13 +204,15 @@ export default class SplitButtonView extends View {
 	 */
 	_createArrowView() {
 		const arrowView = new ButtonView();
+		const bind = arrowView.bindTemplate;
 
 		arrowView.icon = dropdownArrowIcon;
 
 		arrowView.extendTemplate( {
 			attributes: {
 				class: 'ck-splitbutton__arrow',
-				'aria-haspopup': true
+				'aria-haspopup': true,
+				'aria-expanded': bind.to( 'isOn', value => String( value ) )
 			}
 		} );
 

--- a/src/dropdown/button/splitbuttonview.js
+++ b/src/dropdown/button/splitbuttonview.js
@@ -50,6 +50,7 @@ export default class SplitButtonView extends View {
 		this.set( 'icon' );
 		this.set( 'isEnabled', true );
 		this.set( 'isOn', false );
+		this.set( 'isToggleable', false );
 		this.set( 'isVisible', true );
 		this.set( 'keystroke' );
 		this.set( 'label' );
@@ -173,6 +174,7 @@ export default class SplitButtonView extends View {
 			'icon',
 			'isEnabled',
 			'isOn',
+			'isToggleable',
 			'keystroke',
 			'label',
 			'tabindex',

--- a/src/toolbar/block/blockbuttonview.js
+++ b/src/toolbar/block/blockbuttonview.js
@@ -34,6 +34,8 @@ export default class BlockButtonView extends ButtonView {
 		// Hide button on init.
 		this.isVisible = false;
 
+		this.isToggleable = true;
+
 		/**
 		 * Top offset.
 		 *

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -253,7 +253,7 @@ describe( 'ButtonView', () => {
 				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'false' );
 			} );
 
-			it( '-pressed is not present for not toggleable button', () => {
+			it( '-pressed is not present for non–toggleable button', () => {
 				view.isOn = true;
 				expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
 

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -245,11 +245,20 @@ describe( 'ButtonView', () => {
 			} );
 
 			it( '-pressed reacts to #isOn', () => {
+				view.isToggleable = true;
 				view.isOn = true;
 				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'true' );
 
 				view.isOn = false;
 				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'false' );
+			} );
+
+			it( '-pressed is not present for not toggleable button', () => {
+				view.isOn = true;
+				expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
+
+				view.isOn = false;
+				expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
 			} );
 		} );
 

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -249,7 +249,7 @@ describe( 'ButtonView', () => {
 				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'true' );
 
 				view.isOn = false;
-				expect( view.element.attributes[ 'aria-pressed' ] ).to.be.undefined;
+				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'false' );
 			} );
 		} );
 

--- a/tests/button/switchbuttonview.js
+++ b/tests/button/switchbuttonview.js
@@ -24,6 +24,10 @@ describe( 'SwitchButtonView', () => {
 		it( 'sets CSS class', () => {
 			expect( view.element.classList.contains( 'ck-switchbutton' ) ).to.be.true;
 		} );
+
+		it( 'sets isToggleable flag to true', () => {
+			expect( view.isToggleable ).to.be.true;
+		} );
 	} );
 
 	describe( 'render', () => {

--- a/tests/dropdown/button/splitbuttonview.js
+++ b/tests/dropdown/button/splitbuttonview.js
@@ -70,6 +70,14 @@ describe( 'SplitButtonView', () => {
 			expect( view.element.classList.contains( 'ck-splitbutton_open' ) ).to.be.false;
 		} );
 
+		it( 'binds arrowView aria-expanded attribute to #isOn', () => {
+			view.arrowView.isOn = true;
+			expect( view.arrowView.element.getAttribute( 'aria-expanded' ) ).to.equal( 'true' );
+
+			view.arrowView.isOn = false;
+			expect( view.arrowView.element.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
+		} );
+
 		describe( 'activates keyboard navigation for the toolbar', () => {
 			it( 'so "arrowright" on view#arrowView does nothing', () => {
 				const keyEvtData = {

--- a/tests/dropdown/button/splitbuttonview.js
+++ b/tests/dropdown/button/splitbuttonview.js
@@ -30,6 +30,14 @@ describe( 'SplitButtonView', () => {
 			expect( view.actionView.element.classList.contains( 'ck-splitbutton__action' ) ).to.be.true;
 		} );
 
+		it( 'adds isToggleable to view#actionView', () => {
+			expect( view.actionView.isToggleable ).to.be.false;
+
+			view.isToggleable = true;
+
+			expect( view.actionView.isToggleable ).to.be.true;
+		} );
+
 		it( 'creates view#arrowView', () => {
 			expect( view.arrowView ).to.be.instanceOf( ButtonView );
 			expect( view.arrowView.element.classList.contains( 'ck-splitbutton__arrow' ) ).to.be.true;

--- a/tests/toolbar/block/blockbuttonview.js
+++ b/tests/toolbar/block/blockbuttonview.js
@@ -22,6 +22,10 @@ describe( 'BlockButtonView', () => {
 		expect( view.element.classList.contains( 'ck-block-toolbar-button' ) ).to.be.true;
 	} );
 
+	it( 'should be initialized as toggleable button', () => {
+		expect( view.isToggleable ).to.be.true;
+	} );
+
 	describe( 'DOM binding', () => {
 		it( 'should react on `view#top` change', () => {
 			view.top = 0;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improve the functionality of `aria-pressed` attribute in button elements. Closes ckeditor/ckeditor5#1403.

---

### Additional information

sub-pr:
* https://github.com/ckeditor/ckeditor5-alignment/pull/44
* https://github.com/ckeditor/ckeditor5-basic-styles/pull/95
* https://github.com/ckeditor/ckeditor5-block-quote/pull/40
* https://github.com/ckeditor/ckeditor5-heading/pull/128
* https://github.com/ckeditor/ckeditor5-highlight/pull/43
* https://github.com/ckeditor/ckeditor5-image/pull/303
* https://github.com/ckeditor/ckeditor5-link/pull/246
* https://github.com/ckeditor/ckeditor5-list/pull/135
* https://github.com/ckeditor/ckeditor5-paragraph/pull/46