### PR TITLE
ColorGrid should also determine isOn value when new ColorTile is added to collections.

### DIFF
--- a/src/colorgrid/colorgridview.js
+++ b/src/colorgrid/colorgridview.js
@@ -90,6 +90,10 @@ export default class ColorGridView extends View {
 			}
 		} );
 
+		this.items.on( 'add', ( evt, colorTile ) => {
+			colorTile.isOn = colorTile.color === this.selectedColor;
+		} );
+
 		colorDefinitions.forEach( item => {
 			const colorTile = new ColorTileView();
 

--- a/tests/colorgrid/colorgridview.js
+++ b/tests/colorgrid/colorgridview.js
@@ -106,6 +106,23 @@ describe( 'ColorGridView', () => {
 			expect( view.items.get( 2 ).isOn ).to.be.false;
 		} );
 
+		it( 'should determins isOn value when colorTile is added', () => {
+			view.selectedColor = 'gold';
+
+			const tile = new ColorTileView();
+			tile.set( {
+				color: 'gold',
+				label: 'Gold',
+				options: {
+					hasBorder: false
+				}
+			} );
+
+			view.items.add( tile );
+
+			expect( view.items.get( 3 ).isOn ).to.be.true;
+		} );
+
 		describe( 'add colors from definition as child items', () => {
 			it( 'has proper number of elements', () => {
 				expect( view.items.length ).to.equal( 3 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: ColorGrid should also determine `isOn` value when new ColorTile is added to collections.

---

### Additional information

* issue found while testing ckeditor/ckeditor5-font#51