### PR TITLE
I/4992: Added support for creating a `ViewCollection` with initial views

### DIFF
--- a/src/viewcollection.js
+++ b/src/viewcollection.js
@@ -51,10 +51,10 @@ export default class ViewCollection extends Collection {
 	/**
 	 * Creates a new instance of the {@link module:ui/viewcollection~ViewCollection}.
 	 *
-	 * @param {module:utils/locale~Locale} [locale] The {@link module:core/editor/editor~Editor editor's locale} instance.
+	 * @param {Array.<module:ui/view~View>} [initialItems] The initial items of the collection.
 	 */
-	constructor( locale ) {
-		super( {
+	constructor( initialItems = [] ) {
+		super( initialItems, {
 			// An #id Number attribute should be legal and not break the `ViewCollection` instance.
 			// https://github.com/ckeditor/ckeditor5-ui/issues/93
 			idProperty: 'viewUid'
@@ -62,13 +62,7 @@ export default class ViewCollection extends Collection {
 
 		// Handle {@link module:ui/view~View#element} in DOM when a new view is added to the collection.
 		this.on( 'add', ( evt, view, index ) => {
-			if ( !view.isRendered ) {
-				view.render();
-			}
-
-			if ( view.element && this._parentElement ) {
-				this._parentElement.insertBefore( view.element, this._parentElement.children[ index ] );
-			}
+			this._renderViewIntoCollectionParent( view, index );
 		} );
 
 		// Handle {@link module:ui/view~View#element} in DOM when a view is removed from the collection.
@@ -77,14 +71,6 @@ export default class ViewCollection extends Collection {
 				view.element.remove();
 			}
 		} );
-
-		/**
-		 * The {@link module:core/editor/editor~Editor#locale editor's locale} instance.
-		 * See the view {@link module:ui/view~View#locale locale} property.
-		 *
-		 * @member {module:utils/locale~Locale}
-		 */
-		this.locale = locale;
 
 		/**
 		 * A parent element within which child views are rendered and managed in DOM.
@@ -112,6 +98,11 @@ export default class ViewCollection extends Collection {
 	 */
 	setParent( elementOrDocFragment ) {
 		this._parentElement = elementOrDocFragment;
+
+		// Take care of the initial collection items passed to the constructor.
+		for ( const view of this ) {
+			this._renderViewIntoCollectionParent( view );
+		}
 	}
 
 	/**
@@ -192,6 +183,30 @@ export default class ViewCollection extends Collection {
 				} );
 			}
 		};
+	}
+
+	/**
+	 * This method {@link module:ui/view~View#render renders} a new view added to the collection.
+	 *
+	 * If {@link #_parentElement parent element} is set, this method also adds the view's
+	 * {@link module:ui/view~View#element} as a child of the parent in DOM at a specified index.
+	 *
+	 * **Note**: If index is not specified, the view's element is pushed as the last child
+	 * of the parent element.
+	 *
+	 * @private
+	 * @param {module:ui/view~View} view A new view added to the collection.
+	 * @param {Number} [index] An index the view holds in the collection. When not specified,
+	 * the view is added at the end.
+	 */
+	_renderViewIntoCollectionParent( view, index ) {
+		if ( !view.isRendered ) {
+			view.render();
+		}
+
+		if ( view.element && this._parentElement ) {
+			this._parentElement.insertBefore( view.element, this._parentElement.children[ index ] );
+		}
 	}
 
 	/**

--- a/tests/viewcollection.js
+++ b/tests/viewcollection.js
@@ -20,15 +20,18 @@ describe( 'ViewCollection', () => {
 
 	describe( 'constructor()', () => {
 		it( 'sets basic properties and attributes', () => {
-			expect( collection.locale ).to.be.undefined;
 			expect( collection._parentElement ).to.be.null;
 			expect( collection._idProperty ).to.equal( 'viewUid' );
 		} );
 
-		it( 'accepts locale and defines the locale property', () => {
-			const locale = { t() {} };
+		it( 'allows setting initial collection items', () => {
+			const view1 = new View();
+			const view2 = new View();
+			const collection = new ViewCollection( [ view1, view2 ] );
 
-			expect( new ViewCollection( locale ).locale ).to.equal( locale );
+			expect( collection ).to.have.length( 2 );
+			expect( collection.get( 0 ) ).to.equal( view1 );
+			expect( collection.get( 1 ) ).to.equal( view2 );
 		} );
 
 		describe( 'child view management in DOM', () => {
@@ -164,6 +167,28 @@ describe( 'ViewCollection', () => {
 
 			collection.setParent( el );
 			expect( collection._parentElement ).to.equal( el );
+		} );
+
+		it( 'udpates initial collection items in DOM', () => {
+			const view1 = new View();
+			view1.element = document.createElement( 'i' );
+			sinon.spy( view1, 'render' );
+
+			const view2 = new View();
+			view2.element = document.createElement( 'b' );
+			sinon.spy( view2, 'render' );
+
+			const collection = new ViewCollection( [ view1, view2 ] );
+			const parentElement = document.createElement( 'div' );
+
+			expect( collection ).to.have.length( 2 );
+			expect( collection.get( 0 ) ).to.equal( view1 );
+			expect( collection.get( 1 ) ).to.equal( view2 );
+
+			collection.setParent( parentElement );
+			expect( normalizeHtml( parentElement.outerHTML ) ).to.equal( '<div><i></i><b></b></div>' );
+			sinon.assert.calledOnce( view1.render );
+			sinon.assert.calledOnce( view2.render );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added support for creating a `ViewCollection` with initial views. See ckeditor/ckeditor5-utils#221.

---

Requires https://github.com/ckeditor/ckeditor5-utils/pull/309