### PR TITLE
`config` may not exist

### DIFF
--- a/src/toolbar/block/blocktoolbar.js
+++ b/src/toolbar/block/blocktoolbar.js
@@ -148,15 +148,19 @@ export default class BlockToolbar extends Plugin {
 	 * @inheritDoc
 	 */
 	afterInit() {
-		const factory = this.editor.ui.componentFactory;
 		const config = this.editor.config.get( 'blockToolbar' );
+		
+		if (config) {
+			const factory = this.editor.ui.componentFactory;
+			
+			this.toolbarView.fillFromConfig( config, factory );
 
-		this.toolbarView.fillFromConfig( config, factory );
-
-		// Hide panel before executing each button in the panel.
-		for ( const item of this.toolbarView.items ) {
-			item.on( 'execute', () => this._hidePanel( true ), { priority: 'high' } );
+			// Hide panel before executing each button in the panel.
+			for ( const item of this.toolbarView.items ) {
+				item.on( 'execute', () => this._hidePanel( true ), { priority: 'high' } );
+			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
In my repo. [ckeditor5-build-full](https://github.com/Eusen/ckeditor5-build-full)
I've mixed five kinds of editors together to distinguish which one should be created by the type:
 `create(type, el, config)`.
Because in a real project, it is very common to mix multiple editors.

But there is a problem here when using: `this.editor.config.get( 'blockToolbar' )` may not exist.
So we need to add a judgment here. If it doesn't exist, we won't deal with it.