### PR TITLE
Make BlockToolbar work with empty configuration.

### DIFF
--- a/src/toolbar/block/blocktoolbar.js
+++ b/src/toolbar/block/blocktoolbar.js
@@ -149,7 +149,7 @@ export default class BlockToolbar extends Plugin {
 	 */
 	afterInit() {
 		const factory = this.editor.ui.componentFactory;
-		const config = this.editor.config.get( 'blockToolbar' );
+		const config = this.editor.config.get( 'blockToolbar' ) || [];
 
 		this.toolbarView.fillFromConfig( config, factory );
 

--- a/tests/toolbar/block/blocktoolbar.js
+++ b/tests/toolbar/block/blocktoolbar.js
@@ -55,6 +55,17 @@ describe( 'BlockToolbar', () => {
 		expect( BlockToolbar.pluginName ).to.equal( 'BlockToolbar' );
 	} );
 
+	it( 'should work with empty config', async () => {
+		// Remove default editor instance.
+		await editor.destroy();
+
+		expect( async () => {
+			editor = await ClassicTestEditor.create( element, {
+				plugins: [ BlockToolbar ]
+			} );
+		} ).to.not.throw();
+	} );
+
 	describe( 'child views', () => {
 		describe( 'panelView', () => {
 			it( 'should create a view instance', () => {
@@ -212,6 +223,18 @@ describe( 'BlockToolbar', () => {
 				blockToolbar.panelView.isVisible = true;
 
 				expect( blockToolbar.buttonView.tooltip ).to.be.false;
+			} );
+
+			it( 'should hide the #button if empty config was passed', async () => {
+				// Remove default editor instance.
+				await editor.destroy();
+
+				editor = await ClassicTestEditor.create( element, {
+					plugins: [ BlockToolbar ]
+				} );
+
+				const blockToolbar = editor.plugins.get( BlockToolbar );
+				expect( blockToolbar.buttonView.isVisible ).to.be.false;
 			} );
 		} );
 	} );

--- a/tests/toolbar/block/blocktoolbar.js
+++ b/tests/toolbar/block/blocktoolbar.js
@@ -55,15 +55,13 @@ describe( 'BlockToolbar', () => {
 		expect( BlockToolbar.pluginName ).to.equal( 'BlockToolbar' );
 	} );
 
-	it( 'should work with empty config', async () => {
+	it( 'should not throw when empty config is provided', async () => {
 		// Remove default editor instance.
 		await editor.destroy();
 
-		expect( async () => {
-			editor = await ClassicTestEditor.create( element, {
-				plugins: [ BlockToolbar ]
-			} );
-		} ).to.not.throw();
+		editor = await ClassicTestEditor.create( element, {
+			plugins: [ BlockToolbar ]
+		} );
 	} );
 
 	describe( 'child views', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Make `BlockToolbar` work with an empty configuration. Closes ckeditor/ckeditor5#5980.

---

### Additional information

* As discussed in https://github.com/ckeditor/ckeditor5-ui/pull/532 the block toolbar should work with empty toolbar configuration as other features use this pattern.
