### PR TITLE
I/6112: Implemented the `Toolbar#isCompact` property

### DIFF
--- a/src/toolbar/toolbarview.js
+++ b/src/toolbar/toolbarview.js
@@ -168,7 +168,8 @@ export default class ToolbarView extends View {
 				class: [
 					'ck',
 					'ck-toolbar',
-					bind.to( 'class' )
+					bind.to( 'class' ),
+					bind.if( 'isCompact', 'ck-toolbar_compact' ),
 				],
 				role: 'toolbar',
 				'aria-label': bind.to( 'ariaLabel' )

--- a/src/toolbar/toolbarview.js
+++ b/src/toolbar/toolbarview.js
@@ -95,6 +95,15 @@ export default class ToolbarView extends View {
 		this.set( 'class' );
 
 		/**
+		 * When set true, makes the toolbar look compact with {@link #element}.
+		 *
+		 * @observable
+		 * @default false
+		 * @member {String} #isCompact
+		 */
+		this.set( 'isCompact', false );
+
+		/**
 		 * A (child) view containing {@link #items toolbar items}.
 		 *
 		 * @readonly

--- a/tests/toolbar/toolbarview.js
+++ b/tests/toolbar/toolbarview.js
@@ -54,6 +54,10 @@ describe( 'ToolbarView', () => {
 			expect( view.locale ).to.equal( locale );
 		} );
 
+		it( 'should set view#isCompact', () => {
+			expect( view.isCompact ).to.be.false;
+		} );
+
 		describe( '#options', () => {
 			it( 'should be an empty object if none were passed', () => {
 				expect( view.options ).to.deep.equal( {} );
@@ -165,6 +169,14 @@ describe( 'ToolbarView', () => {
 				view.class = false;
 				expect( view.element.classList.contains( 'foo' ) ).to.be.false;
 				expect( view.element.classList.contains( 'bar' ) ).to.be.false;
+			} );
+
+			it( 'reacts on view#isCompact', () => {
+				view.isCompact = false;
+				expect( view.element.classList.contains( 'ck-toolbar_compact' ) ).to.be.false;
+
+				view.isCompact = true;
+				expect( view.element.classList.contains( 'ck-toolbar_compact' ) ).to.be.true;
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented the `Toolbar#isCompact` property to turn regular toolbars into compact ones (with less spacing) (see ckeditor/ckeditor5#6112)

---

### Additional information

A piece of https://github.com/ckeditor/ckeditor5-table/pull/232.