### PR TITLE
In ContextualBalloon#remove cache stack id before currently shown view is changed

### DIFF
--- a/src/panel/balloon/contextualballoon.js
+++ b/src/panel/balloon/contextualballoon.js
@@ -258,6 +258,7 @@ export default class ContextualBalloon extends Plugin {
 		}
 
 		const stack = this._viewToStack.get( view );
+		const stackId = this._getStackId( stack );
 
 		if ( this._singleViewMode && this.visibleView === view ) {
 			this._singleViewMode = false;
@@ -280,7 +281,7 @@ export default class ContextualBalloon extends Plugin {
 		}
 
 		if ( stack.size === 1 ) {
-			this._idToStack.delete( this._getStackId( stack ) );
+			this._idToStack.delete( stackId );
 			this._numberOfStacks = this._idToStack.size;
 		} else {
 			stack.delete( view );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: In `ContextualBalloon#remove` cache stack id before currently shown view is changed.

---

### Additional information

This change prevents an editor crash when `ContextualBalloon#remove` fires itself with the same view (as an effect of a chain of events).

See linked CF issue.

Following interaction happens in the comments feature:

1. Selection is in two comments markers, inside the inner comment, the balloon has two views.
2. Selection is moved to the outer marker, `remove()` is fired.
3. Inside `remove()` a couple of things happen that lead to firing `remove()` again with the same view.
4. The view is removed in the "second" `remove()`.
5. But then it crashes when the execution flow goes back to the original `remove()`.

This fix prevents crashing in the original `remove()` by saving `stackId`.