### PR TITLE
i/6548: Removed the obsolete DropdownView#focusTracker.

### DIFF
--- a/src/dropdown/dropdownview.js
+++ b/src/dropdown/dropdownview.js
@@ -8,7 +8,6 @@
  */
 
 import View from '../view';
-import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 import KeystrokeHandler from '@ckeditor/ckeditor5-utils/src/keystrokehandler';
 
 import '../../theme/components/dropdown/dropdown.css';
@@ -156,14 +155,6 @@ export default class DropdownView extends View {
 		this.set( 'panelPosition', 'auto' );
 
 		/**
-		 * Tracks information about DOM focus in the dropdown.
-		 *
-		 * @readonly
-		 * @member {module:utils/focustracker~FocusTracker}
-		 */
-		this.focusTracker = new FocusTracker();
-
-		/**
 		 * Instance of the {@link module:utils/keystrokehandler~KeystrokeHandler}. It manages
 		 * keystrokes of the dropdown:
 		 *
@@ -276,9 +267,6 @@ export default class DropdownView extends View {
 
 		// Listen for keystrokes coming from within #element.
 		this.keystrokes.listenTo( this.element );
-
-		// Register #element in the focus tracker.
-		this.focusTracker.add( this.element );
 
 		const closeDropdown = ( data, cancel ) => {
 			if ( this.isOpen ) {

--- a/tests/dropdown/dropdownview.js
+++ b/tests/dropdown/dropdownview.js
@@ -5,7 +5,6 @@
 
 import DropdownView from '../../src/dropdown/dropdownview';
 import KeystrokeHandler from '@ckeditor/ckeditor5-utils/src/keystrokehandler';
-import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import ButtonView from '../../src/button/buttonview';
 import DropdownPanelView from '../../src/dropdown/dropdownpanelview';
@@ -70,10 +69,6 @@ describe( 'DropdownView', () => {
 
 		it( 'sets view#panelPosition "auto"', () => {
 			expect( view.panelPosition ).to.equal( 'auto' );
-		} );
-
-		it( 'creates #focusTracker instance', () => {
-			expect( view.focusTracker ).to.be.instanceOf( FocusTracker );
 		} );
 
 		it( 'creates #keystrokeHandler instance', () => {
@@ -206,20 +201,6 @@ describe( 'DropdownView', () => {
 				new DropdownPanelView( locale ) );
 
 			const spy = sinon.spy( view.keystrokes, 'listenTo' );
-
-			view.render();
-			sinon.assert.calledOnce( spy );
-			sinon.assert.calledWithExactly( spy, view.element );
-
-			view.element.remove();
-		} );
-
-		it( 'adds #element to #focusTracker', () => {
-			const view = new DropdownView( locale,
-				new ButtonView( locale ),
-				new DropdownPanelView( locale ) );
-
-			const spy = sinon.spy( view.focusTracker, 'add' );
 
 			view.render();
 			sinon.assert.calledOnce( spy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed the obsolete `DropdownView#focusTracker`. Closes ckeditor/ckeditor5#6548.

BREAKING CHANGE: The `DropdownView#focusTracker` property has been removed.
